### PR TITLE
chore(release): bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v2.0.0 (2025-08-30)
+
+### Feat
+
+- **web**: implement basic GUI interface (#65)
+- **core**: async search; add 9 sites; add AES notes/helpers; archive deqixs.com (#64)
+
+### Refactor
+
+- **core**: optimize structure; simplify config; maintainable parsers; refresh web UI (#68)
+- **ocr**: generalize FontOCR class, add lazy-loading, simplify Qidian parser (#66)
+- remove TUI and browser mode; unify downloader/exporter; add support for 10+ sites (#63)
+
 ## v1.5.0 (2025-07-21)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ testpaths = ["tests"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.5.0"
+version = "2.0.0"
 version_files = [
     "src/novel_downloader/__init__.py"
 ]

--- a/src/novel_downloader/__init__.py
+++ b/src/novel_downloader/__init__.py
@@ -6,7 +6,7 @@ novel_downloader
 Core package for the Novel Downloader project.
 """
 
-__version__ = "1.5.0"
+__version__ = "2.0.0"
 
 __author__ = "Saudade Z"
 __email__ = "saudadez217@gmail.com"


### PR DESCRIPTION
### Description

Bump version from 1.5.0 to 2.0.0 for release.

---

### Changes

- Version bump only

---

### Type of change

- [x] Chore (release preparation)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
