### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.1.0 (2025-09-15)
+
+### Feat
+
+- **core**: add 20 sites, archive 3, richer logging, URL auto-resolve, EPUB hardening (#80)
+- **web**: use search_stream and add /history page (#79)
+- **core**: lazy-load registries to remove implicit imports (#78)
+
 ## v2.0.2 (2025-09-10)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ testpaths = ["tests"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.0.2"
+version = "2.1.0"
 version_files = [
     "src/novel_downloader/__init__.py"
 ]

--- a/src/novel_downloader/__init__.py
+++ b/src/novel_downloader/__init__.py
@@ -6,7 +6,7 @@ novel_downloader
 Core package for the Novel Downloader project.
 """
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 
 __author__ = "Saudade Z"
 __email__ = "saudadez217@gmail.com"


### PR DESCRIPTION
### Description

Bump version from 2.0.2 to 2.1.0 for release.

---

### Changes

- Version bump only
