### PR TITLE
feat(web): add URL input mode to download page

### DIFF
--- a/src/novel_downloader/cli/search.py
+++ b/src/novel_downloader/cli/search.py
@@ -31,7 +31,12 @@ def register_search_subcommand(subparsers: _SubParsersAction) -> None:  # type: 
     parser.add_argument("keyword", help=t("search_keyword_help"))
     parser.add_argument("--config", type=str, help=t("help_config"))
     parser.add_argument(
-        "--limit", "-l", type=int, default=200, metavar="N", help=t("search_limit_help")
+        "--limit",
+        "-l",
+        type=int,
+        default=None,
+        metavar="N",
+        help=t("search_limit_help"),
     )
     parser.add_argument(
         "--site-limit",
@@ -57,7 +62,7 @@ def handle_search(args: Namespace) -> None:
 
     sites: Sequence[str] | None = args.site or None
     keyword: str = args.keyword
-    overall_limit = max(1, args.limit)
+    overall_limit = None if args.limit is None else max(1, args.limit)
     per_site_limit = max(1, args.site_limit)
     timeout = max(0.1, float(args.timeout))
     config_path: Path | None = Path(args.config) if args.config else None


### PR DESCRIPTION
### Description

This PR adds a new **URL input mode** to the `/download` page.

Users can now either:
- Paste a full novel URL and let the system auto-resolve the site and book ID, or
- Select a site and manually enter the book ID.

---

### Changes

- Added `mode` toggle to switch between **URL** and **Site + ID** input methods.
- Integrated `resolve_book_url` to parse full URLs into standardized `{site_key, book_id}`.
- Added real-time URL preview showing parsed site and ID when URL mode is used.
- Improved input validation and error handling with clear `ui.notify` messages.
- Prevent duplicate clicks by disabling the "Add to queue" button while processing.
- Auto-detects if a URL is pasted into the **ID mode** and switches to URL mode for convenience.

---

### Motivation

Previously, users were required to manually select a site and enter the book ID, even if they already had the full URL.

This enhancement makes the download page more user-friendly by supporting direct URL input, reducing user errors and improving overall usability.

---

### Type of change

- [x] New feature (non-breaking change that adds functionality)
