### PR TITLE
feat(sfacg): add support for VIP content with OCR

### DIFF
--- a/docs/4-supported-sites.md
+++ b/docs/4-supported-sites.md
@@ -336,6 +336,10 @@ novel-cli download --site ttkan shengxu-chendong
   * 书籍: `https://m.sfacg.com/b/456123/` -> Book ID: `456123`
   * 章节: `https://m.sfacg.com/c/5417665/` -> Chapter ID: `5417665`
   * 登录: 需提供有效的 Cookie 才能访问订阅章节。
+  * 其它:
+    * VIP 章节以图片形式返回, 可通过开启 `decode_font` 参数配合 OCR 识别为文本。
+    * OCR 识别结果并非完全可靠, 准确率大约在 **80%+**, 可能存在错误或缺字。
+    * OCR 运算在 CPU 环境下较为耗时, 解析 VIP 章节速度会明显变慢, 建议在具备 GPU 的环境中运行。
 
 * **三七轻小说 (n37yq)**
   * 书籍: `https://www.37yq.com/lightnovel/2362.html` -> Book ID: `2362`

--- a/src/novel_downloader/core/downloaders/sfacg.py
+++ b/src/novel_downloader/core/downloaders/sfacg.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.core.downloaders.sfacg
+---------------------------------------
+
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from novel_downloader.core.downloaders.base import BaseDownloader
+from novel_downloader.core.downloaders.registry import register_downloader
+from novel_downloader.core.downloaders.signals import STOP, Progress, StopToken
+from novel_downloader.models import BookConfig, ChapterDict
+from novel_downloader.utils.chapter_storage import ChapterStorage
+from novel_downloader.utils.time_utils import async_jitter_sleep
+
+
+@register_downloader(site_keys=["sfacg"])
+class SfacgDownloader(BaseDownloader):
+    """
+    Specialized Async downloader for sfacg novel sites.
+    """
+
+    async def _download_one(
+        self,
+        book: BookConfig,
+        *,
+        progress_hook: Callable[[int, int], Awaitable[None]] | None = None,
+        cancel_event: asyncio.Event | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Sentinel-based pipeline with cancellation:
+
+        Producer -> ChapterWorkers -> StorageWorker.
+
+        On cancel: stop producing, workers finish at most one chapter,
+        storage drains, flushes, and exits.
+        """
+        NUM_WORKERS = 1
+
+        book_id = book["book_id"]
+        start_id = book.get("start_id")
+        end_id = book.get("end_id")
+        ignore_set = set(book.get("ignore_ids", []))
+
+        raw_base = self._raw_data_dir / book_id
+        raw_base.mkdir(parents=True, exist_ok=True)
+
+        def cancelled() -> bool:
+            return bool(cancel_event and cancel_event.is_set())
+
+        # --- metadata ---
+        book_info = await self._load_book_info(book_id=book_id)
+        if not book_info:
+            return
+
+        vols = book_info["volumes"]
+        plan = self._select_chapter_ids(vols, start_id, end_id, ignore_set)
+        if not plan:
+            self.logger.info("Nothing to do after filtering: %s", book_id)
+            return
+
+        progress = Progress(total=len(plan), hook=progress_hook)
+
+        # --- queues & batching ---
+        cid_q: asyncio.Queue[str] = asyncio.Queue(maxsize=2)
+        save_q: asyncio.Queue[ChapterDict | StopToken] = asyncio.Queue(maxsize=10)
+        batch: list[ChapterDict] = []
+
+        async def flush_batch() -> None:
+            if not batch:
+                return
+            try:
+                storage.upsert_chapters(batch, self.DEFAULT_SOURCE_ID)
+            except Exception as e:
+                self.logger.error(
+                    "Storage batch upsert failed (size=%d): %s",
+                    len(batch),
+                    e,
+                    exc_info=True,
+                )
+            else:
+                await progress.bump(len(batch))
+            finally:
+                batch.clear()
+
+        # --- storage worker ---
+        async def storage_worker() -> None:
+            while True:
+                item = await save_q.get()
+                if isinstance(item, StopToken):
+                    # drain any remaining items before exiting
+                    while not save_q.empty():
+                        nxt = save_q.get_nowait()
+                        if not isinstance(nxt, StopToken):
+                            batch.append(nxt)
+                            if len(batch) >= self._storage_batch_size:
+                                await flush_batch()
+                    await flush_batch()
+                    return
+                batch.append(item)
+                if len(batch) >= self._storage_batch_size:
+                    await flush_batch()
+
+        # --- chapter worker ---
+        async def chapter_worker() -> None:
+            try:
+                while True:
+                    if cancelled() and cid_q.empty():
+                        return
+                    try:
+                        cid = await asyncio.wait_for(cid_q.get(), timeout=0.5)
+                    except TimeoutError:
+                        if producer_task.done() and cid_q.empty():
+                            return
+                        continue
+
+                    chap = await self._process_chapter(book_id, cid)
+                    if chap:
+                        await save_q.put(chap)
+
+                    # polite pacing
+                    await async_jitter_sleep(
+                        self._request_interval,
+                        mul_spread=1.1,
+                        max_sleep=self._request_interval + 2,
+                    )
+            except asyncio.CancelledError:
+                # allow graceful unwinding
+                return
+
+        # --- producer ---
+        async def producer() -> None:
+            for cid in plan:
+                if cancelled():
+                    break
+                if self._skip_existing and storage.exists(cid):
+                    await progress.bump(1)
+                else:
+                    await cid_q.put(cid)
+
+        # --- run the pipeline ---
+        with ChapterStorage(raw_base, priorities=self.PRIORITIES_MAP) as storage:
+            storage_task = asyncio.create_task(storage_worker())
+            async with asyncio.TaskGroup() as tg:
+                worker_tasks = [
+                    tg.create_task(chapter_worker()) for _ in range(NUM_WORKERS)
+                ]
+                producer_task = tg.create_task(producer())
+
+            if cancel_event:
+
+                async def cancel_watcher() -> None:
+                    await cancel_event.wait()
+                    producer_task.cancel()
+                    for t in worker_tasks:
+                        t.cancel()
+
+                asyncio.create_task(cancel_watcher())
+
+            await save_q.put(STOP)
+            await storage_task
+
+        # --- done ---
+        if cancelled():
+            self.logger.info(
+                "Novel '%s' cancelled: flushed %d/%d chapters.",
+                book_info.get("book_name", "unknown"),
+                progress.done,
+                progress.total,
+            )
+        else:
+            self.logger.info(
+                "Novel '%s' download completed.",
+                book_info.get("book_name", "unknown"),
+            )
+
+    async def _process_chapter(
+        self,
+        book_id: str,
+        cid: str,
+    ) -> ChapterDict | None:
+        """
+        Fetches, saves raw HTML, parses a single chapter,
+        retrying up to self.retry_times.
+
+        :return: ChapterDict on success, or None on failure.
+        """
+        for attempt in range(self._retry_times + 1):
+            try:
+                html_list = await self.fetcher.get_book_chapter(book_id, cid)
+                self._save_html_pages(book_id, cid, html_list)
+                if html_list and "本章为VIP章节" in html_list[0]:
+                    self.logger.warning(
+                        "VIP chapter %s :: not purchased, skipping",
+                        cid,
+                    )
+                    return None
+
+                chap = await asyncio.to_thread(
+                    self.parser.parse_chapter, html_list, cid
+                )
+                if not chap:
+                    # check VIP indicator
+                    if html_list and "/ajax/ashx/common.ashx" in html_list[0]:
+                        self.logger.warning(
+                            "VIP chapter %s :: no content after parse (skipping)",
+                            cid,
+                        )
+                        return None
+                    raise ValueError("Empty parse result")
+                imgs = self._extract_img_urls(chap["content"])
+                img_dir = self._raw_data_dir / book_id / "images"
+                await self.fetcher.download_images(img_dir, imgs)
+                return chap
+            except Exception as e:
+                if attempt < self._retry_times:
+                    self.logger.info("Retry chapter %s (%s): %s", cid, attempt + 1, e)
+                    backoff = self._backoff_factor * (2**attempt)
+                    await async_jitter_sleep(
+                        base=backoff, mul_spread=1.2, max_sleep=backoff + 3
+                    )
+                else:
+                    self.logger.warning("Failed chapter %s: %s", cid, e)
+        return None

--- a/src/novel_downloader/resources/config/settings.toml
+++ b/src/novel_downloader/resources/config/settings.toml
@@ -69,6 +69,12 @@ split_mode = "book"                # 导出方式: book / volume
 login_required = false
 request_interval = 2.5
 
+[sites.sfacg]
+login_required = true
+
+[sites.yamibo]
+login_required = false
+
 [sites.common]
 login_required = false
 

--- a/src/novel_downloader/utils/fontocr/core.py
+++ b/src/novel_downloader/utils/fontocr/core.py
@@ -177,6 +177,119 @@ class FontOCR:
             return np.asarray(im)
 
     @staticmethod
+    def gif_to_array(path: Path) -> np.ndarray:
+        """
+        Convert a GIF image into a numpy array with white background.
+
+        :param path: Path to the GIF file
+        :return: Numpy array representing the image (H, W, 3)
+        """
+        with Image.open(path) as img:
+            img = img.convert("RGBA")
+            background = Image.new("RGBA", img.size, (255, 255, 255, 255))
+            background.paste(img, mask=img.getchannel("A"))
+            return np.array(background.convert("RGB"))
+
+    @staticmethod
+    def gif_to_array_bytes(data: bytes) -> np.ndarray:
+        """
+        Convert a GIF (in bytes) into a numpy array with white background.
+
+        :param data: Raw GIF bytes
+        :return: Numpy array representing the image (H, W, 3)
+        """
+        with Image.open(io.BytesIO(data)) as img:
+            img = img.convert("RGBA")
+            background = Image.new("RGBA", img.size, (255, 255, 255, 255))
+            background.paste(img, mask=img.getchannel("A"))
+            return np.array(background.convert("RGB"))
+
+    @staticmethod
+    def filter_orange_watermark(img: np.ndarray) -> np.ndarray:
+        """
+        Remove orange-like watermark colors by replacing them with white.
+
+        :param img: Input image as numpy array (H, W, 3)
+        :return: Filtered numpy array (H, W, 3)
+        """
+        pil_img = Image.fromarray(img).convert("HSV")
+        hsv_arr = np.array(pil_img)
+
+        lower_h, upper_h = int(10 / 360 * 255), int(40 / 360 * 255)
+
+        mask_orange = (
+            (hsv_arr[:, :, 0] >= lower_h)
+            & (hsv_arr[:, :, 0] <= upper_h)
+            & (hsv_arr[:, :, 1] > 50)
+            & (hsv_arr[:, :, 2] > 100)
+        )
+
+        img[mask_orange] = [255, 255, 255]
+        return img
+
+    @staticmethod
+    def split_by_height(
+        img: np.ndarray,
+        height: int = 38,
+        top_offset: int = 10,
+        bottom_offset: int = 10,
+        per_chunk_top_ignore: int = 10,
+    ) -> list[np.ndarray]:
+        """
+        Split an image vertically into chunks of fixed height,
+        with optional global offsets and per-chunk top ignore.
+
+        :param img: Numpy array representing the image (H, W, 3)
+        :param height: Height of each chunk
+        :param top_offset: Number of pixels to skip from the top (whole image)
+        :param bottom_offset: Number of pixels to skip from the bottom (whole image)
+        :param per_chunk_top_ignore: Number of pixels to skip from the top of each chunk
+        :return: List of numpy arrays, each a sub-image of the original
+        """
+        h, w, _ = img.shape
+        chunks = []
+        effective_height = h - top_offset - bottom_offset
+
+        for y in range(0, effective_height, height):
+            chunk = img[top_offset + y : top_offset + y + height, :, :]
+            if per_chunk_top_ignore > 0 and chunk.shape[0] > per_chunk_top_ignore:
+                chunk = chunk[per_chunk_top_ignore:, :, :]
+            chunks.append(chunk)
+
+        return chunks
+
+    @staticmethod
+    def crop_chars_region(
+        img: np.ndarray,
+        num_chars: int,
+        left_margin: int = 14,
+        char_width: int = 28,
+    ) -> np.ndarray:
+        """
+        Crop the image to keep only the region that covers the specified
+        number of characters starting after the left margin.
+
+        :param img: Input image as (H, W, 3) numpy array
+        :param num_chars: How many characters to keep
+        :param left_margin: Number of columns to skip from the left
+        :param char_width: Width of one character (in pixels)
+        :return: Cropped image as (H, W', 3)
+        """
+        h, w, _ = img.shape
+        end_col = min(left_margin + char_width * num_chars, w)
+        return img[:, :end_col, :]
+
+    @staticmethod
+    def is_empty_image(img: np.ndarray) -> bool:
+        """
+        Check if the image is completely white (255, 255, 255).
+
+        :param img: Input image as (H, W, 3) numpy array
+        :return: True if all pixels are white, False otherwise
+        """
+        return bool(np.all(img == 255))
+
+    @staticmethod
     def load_render_font(
         font_path: Path | str, char_size: int = 52
     ) -> ImageFont.FreeTypeFont:


### PR DESCRIPTION
### Description

Add support for parsing and fetching VIP chapters on **sfacg**.

This includes handling image-based VIP content and using OCR to recover paragraphs from encrypted chapter images.

---

### Changes

- **Fetcher**
  - Rewritten to detect VIP chapters and request image content from `/ajax/ashx/common.ashx`.
  - Base64 encode VIP chapter images to fit into the existing `list[str]` API.

- **Parser**
  - Updated to handle both normal HTML chapters and VIP image-based chapters.
  - Added OCR-based decoding pipeline to convert VIP images into readable text paragraphs.
  - Integrated new helpers from `fontocr` for preprocessing and recognition.
  - Added logging and safe fallbacks when VIP data or OCR is missing.

---

### Motivation

sfacg VIP chapters were previously inaccessible because they are served as images instead of plain HTML.

With this update, VIP content can now be fetched, decoded, and parsed into text paragraphs.

---

### Related Issues

Fixes #89

---

### Type of change

- [x] New feature (non-breaking change which adds functionality)
