### PR TITLE
fix(cli): prevent export when download step fails

### DIFF
--- a/src/novel_downloader/cli/commands/download.py
+++ b/src/novel_downloader/cli/commands/download.py
@@ -140,7 +140,7 @@ class DownloadCmd(Command):
 
         from novel_downloader.cli.services.download import download_books
 
-        asyncio.run(
+        success = asyncio.run(
             download_books(
                 site,
                 books,
@@ -150,6 +150,8 @@ class DownloadCmd(Command):
                 adapter.get_login_config(),
             )
         )
+        if not success:
+            return
 
         # export
         if not args.no_export:

--- a/src/novel_downloader/cli/commands/search.py
+++ b/src/novel_downloader/cli/commands/search.py
@@ -63,7 +63,6 @@ class SearchCmd(Command):
         import asyncio
 
         from novel_downloader.cli.services.download import download_books
-        from novel_downloader.cli.services.export import export_books
         from novel_downloader.core.searchers import search
 
         sites: Sequence[str] | None = args.site or None
@@ -117,7 +116,7 @@ class SearchCmd(Command):
             log_level = adapter.get_log_level()
             ui.setup_logging(console_level=log_level)
 
-            await download_books(
+            success = await download_books(
                 chosen["site"],
                 books,
                 adapter.get_downloader_config(),
@@ -125,8 +124,12 @@ class SearchCmd(Command):
                 adapter.get_parser_config(),
                 adapter.get_login_config(),
             )
+            if not success:
+                return
 
             # export
+            from novel_downloader.cli.services.export import export_books
+
             export_books(
                 site=chosen["site"],
                 books=books,

--- a/src/novel_downloader/cli/services/download.py
+++ b/src/novel_downloader/cli/services/download.py
@@ -25,8 +25,8 @@ async def download_book(
     fetcher_cfg: FetcherConfig,
     parser_cfg: ParserConfig,
     login_config: dict[str, str] | None = None,
-) -> None:
-    await download_books(
+) -> bool:
+    return await download_books(
         site,
         [book],
         downloader_cfg,
@@ -43,14 +43,14 @@ async def download_books(
     fetcher_cfg: FetcherConfig,
     parser_cfg: ParserConfig,
     login_config: dict[str, str] | None = None,
-) -> None:
+) -> bool:
     parser = get_parser(site, parser_cfg)
 
     async with get_fetcher(site, fetcher_cfg) as fetcher:
         if downloader_cfg.login_required and (
             not await ensure_login(fetcher, login_config)
         ):
-            return
+            return False
 
         downloader = get_downloader(
             fetcher=fetcher,
@@ -76,3 +76,4 @@ async def download_books(
 
         if downloader_cfg.login_required and fetcher.is_logged_in:
             await fetcher.save_state()
+    return True

--- a/src/novel_downloader/core/exporters/base.py
+++ b/src/novel_downloader/core/exporters/base.py
@@ -215,14 +215,21 @@ class BaseExporter(abc.ABC):
             self.logger.error("Corrupt JSON in %s: %s", info_path, e)
         return None
 
-    def _init_chapter_storages(self, book_id: str) -> None:
+    def _init_chapter_storages(self, book_id: str) -> bool:
         if book_id in self._storage_cache:
-            return
+            return True
+        raw_base = self._raw_data_dir / book_id
+        if not raw_base.is_dir():
+            self.logger.warning(
+                "Chapter storage base does not exist for book_id=%s", book_id
+            )
+            return False
         self._storage_cache[book_id] = ChapterStorage(
-            raw_base=self._raw_data_dir / book_id,
+            raw_base=raw_base,
             priorities=self.PRIORITIES_MAP,
         )
         self._storage_cache[book_id].connect()
+        return True
 
     def _close_chapter_storages(self) -> None:
         for storage in self._storage_cache.values():

--- a/src/novel_downloader/core/exporters/common.py
+++ b/src/novel_downloader/core/exporters/common.py
@@ -71,7 +71,8 @@ class CommonExporter(BaseExporter):
         end_id = book.get("end_id")
         ignore_set = set(book.get("ignore_ids", []))
 
-        self._init_chapter_storages(book_id)
+        if not self._init_chapter_storages(book_id):
+            return None
 
         # --- Load book_info.json ---
         book_info = self._load_book_info(book_id)
@@ -166,7 +167,8 @@ class CommonExporter(BaseExporter):
         end_id = book.get("end_id")
         ignore_set = set(book.get("ignore_ids", []))
 
-        self._init_chapter_storages(book_id)
+        if not self._init_chapter_storages(book_id):
+            return None
 
         # --- Load book_info.json ---
         book_info = self._load_book_info(book_id)
@@ -305,7 +307,8 @@ class CommonExporter(BaseExporter):
         end_id = book.get("end_id")
         ignore_set = set(book.get("ignore_ids", []))
 
-        self._init_chapter_storages(book_id)
+        if not self._init_chapter_storages(book_id):
+            return None
 
         # --- Load book_info.json ---
         book_info = self._load_book_info(book_id)


### PR DESCRIPTION
### Description

This PR fixes an issue in the export flow where the CLI would continue to the export step even if the download step failed, leading to errors like:

```
OperationalError: unable to open database file
```

---

### Changes

* **exporter**
  * `_init_chapter_storages` now checks if the underlying DB path exists before `sqlite3.connect`.
  * Returns `False` if storage cannot be initialized.

* **cli/services/download.py**
  * `download_book` / `download_books` now return `bool` (`True` on success, `False` on failure).
  * CLI commands (`download`, `search`) now stop execution early if download fails, skipping export.

---

### Motivation

Previously, when login failed, the related download was skipped, but the CLI would still attempt export. This caused crashes when the expected database file did not exist.

With this change, the CLI respects download failures and avoids running export steps, ensuring a smoother and safer user experience.

---

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
