### PR TITLE
fix(shuhaige): handle multi-page chapters and filter ads

### DIFF
--- a/src/novel_downloader/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/src/novel_downloader/locales/zh_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: novel-downloader 2.2.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-28 00:32-0400\n"
+"POT-Creation-Date: 2025-10-01 02:05-0400\n"
 "PO-Revision-Date: 2025-09-22 22:43-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -211,7 +211,7 @@ msgstr "从配置读取书籍 ID 失败：{err}"
 msgid "No book IDs provided. Exiting."
 msgstr "未提供书籍 ID，已退出"
 
-#: src\novel_downloader\apps\cli\commands\download.py:145
+#: src\novel_downloader\apps\cli\commands\download.py:151
 msgid "Export skipped (--no-export)"
 msgstr "已跳过导出 (--no-export)"
 
@@ -239,91 +239,91 @@ msgstr "未选择任何站点。"
 msgid "No books selected."
 msgstr "未选择任何书籍。"
 
-#: src\novel_downloader\apps\cli\commands\export.py:135
+#: src\novel_downloader\apps\cli\commands\export.py:141
 #, python-brace-format
 msgid "Raw data directory does not exist: {p}"
 msgstr "原始数据目录不存在：{p}"
 
-#: src\novel_downloader\apps\cli\commands\export.py:140
+#: src\novel_downloader\apps\cli\commands\export.py:146
 #, python-brace-format
 msgid "No sites found under {p}."
 msgstr "在 {p} 下未找到任何站点。"
 
-#: src\novel_downloader\apps\cli\commands\export.py:158
+#: src\novel_downloader\apps\cli\commands\export.py:164
 #, python-brace-format
 msgid "Available Sites · Page {page}/{total}"
 msgstr "可用站点 · 第 {page}/{total} 页"
 
-#: src\novel_downloader\apps\cli\commands\export.py:161
-#: src\novel_downloader\apps\cli\commands\export.py:235
+#: src\novel_downloader\apps\cli\commands\export.py:167
+#: src\novel_downloader\apps\cli\commands\export.py:241
 #: src\novel_downloader\apps\cli\commands\search.py:141
 msgid "#"
 msgstr "序号"
 
-#: src\novel_downloader\apps\cli\commands\export.py:161
+#: src\novel_downloader\apps\cli\commands\export.py:167
 #: src\novel_downloader\apps\cli\commands\search.py:146
 msgid "Site Name"
 msgstr "站点名称"
 
-#: src\novel_downloader\apps\cli\commands\export.py:161
+#: src\novel_downloader\apps\cli\commands\export.py:167
 msgid "Site Key"
 msgstr "站点键"
 
-#: src\novel_downloader\apps\cli\commands\export.py:174
+#: src\novel_downloader\apps\cli\commands\export.py:180
 #: src\novel_downloader\apps\cli\commands\search.py:185
 msgid "Enter a number, 'n' for next, 'p' for previous (press Enter to cancel)"
 msgstr "输入序号选择，'n' 下一页，'p' 上一页（回车取消）"
 
-#: src\novel_downloader\apps\cli\commands\export.py:199
+#: src\novel_downloader\apps\cli\commands\export.py:205
 #, python-brace-format
 msgid "Site directory does not exist: {p}"
 msgstr "站点目录不存在：{p}"
 
-#: src\novel_downloader\apps\cli\commands\export.py:204
+#: src\novel_downloader\apps\cli\commands\export.py:210
 #, python-brace-format
 msgid "No books found under site '{site}'."
 msgstr "在站点 '{site}' 下未找到任何书籍。"
 
-#: src\novel_downloader\apps\cli\commands\export.py:219
+#: src\novel_downloader\apps\cli\commands\export.py:225
 #, python-brace-format
 msgid "Failed to read metadata for {bid}"
 msgstr "读取 {bid} 的元数据失败"
 
-#: src\novel_downloader\apps\cli\commands\export.py:232
+#: src\novel_downloader\apps\cli\commands\export.py:238
 #, python-brace-format
 msgid "Available Books for {site} · Page {page}/{total}"
 msgstr "{site} 的可用书籍 · 第 {page}/{total} 页"
 
-#: src\novel_downloader\apps\cli\commands\export.py:235
+#: src\novel_downloader\apps\cli\commands\export.py:241
 #: src\novel_downloader\apps\cli\commands\search.py:147
 #: src\novel_downloader\apps\web\pages\download.py:72
 #: src\novel_downloader\apps\web\pages\progress.py:142
 msgid "Book ID"
 msgstr "书籍 ID"
 
-#: src\novel_downloader\apps\cli\commands\export.py:235
+#: src\novel_downloader\apps\cli\commands\export.py:241
 #: src\novel_downloader\apps\cli\commands\search.py:142
 #: src\novel_downloader\apps\web\pages\search.py:302
 msgid "Title"
 msgstr "书名"
 
-#: src\novel_downloader\apps\cli\commands\export.py:235
+#: src\novel_downloader\apps\cli\commands\export.py:241
 #: src\novel_downloader\apps\cli\commands\search.py:143
 #: src\novel_downloader\apps\web\pages\search.py:303
 msgid "Author"
 msgstr "作者"
 
-#: src\novel_downloader\apps\cli\commands\export.py:248
+#: src\novel_downloader\apps\cli\commands\export.py:254
 msgid ""
 "Enter numbers (e.g. 1,3,5), 'a' for all, 'n' next, 'p' previous (Enter to "
 "cancel)"
 msgstr "输入序号 (如 1,3,5)，'a' 全选，'n' 下一页，'p' 上一页（回车取消）"
 
-#: src\novel_downloader\apps\cli\commands\export.py:267
+#: src\novel_downloader\apps\cli\commands\export.py:273
 msgid "Invalid input."
 msgstr "输入无效。"
 
-#: src\novel_downloader\apps\cli\commands\export.py:270
+#: src\novel_downloader\apps\cli\commands\export.py:276
 msgid "One or more indices out of range."
 msgstr "一个或多个索引超出范围。"
 

--- a/src/novel_downloader/plugins/sites/b520/parser.py
+++ b/src/novel_downloader/plugins/sites/b520/parser.py
@@ -100,8 +100,6 @@ class B520Parser(BaseParser):
         paragraphs = [
             "".join(p.itertext()).strip() for p in content_elem[0].xpath(".//p")
         ]
-        if paragraphs and "www.shuhaige.net" in paragraphs[-1]:
-            paragraphs.pop()
 
         content = "\n".join(paragraphs)
         if not content.strip():

--- a/src/novel_downloader/plugins/sites/shuhaige/fetcher.py
+++ b/src/novel_downloader/plugins/sites/shuhaige/fetcher.py
@@ -19,5 +19,15 @@ class ShuhaigeSession(GenericSession):
 
     site_name: str = "shuhaige"
 
+    BASE_URL = "https://www.shuhaige.net"
     BOOK_INFO_URL = "https://www.shuhaige.net/{book_id}/"
-    CHAPTER_URL = "https://www.shuhaige.net/{book_id}/{chapter_id}.html"
+
+    USE_PAGINATED_CHAPTER = True
+
+    @classmethod
+    def relative_chapter_url(cls, book_id: str, chapter_id: str, idx: int) -> str:
+        return (
+            f"/{book_id}/{chapter_id}_{idx}.html"
+            if idx > 1
+            else f"/{book_id}/{chapter_id}.html"
+        )


### PR DESCRIPTION
### Description

Fixes the issue where only the first page of a shuhaige chapter was being fetched.

Now the fetcher correctly retrieves all pages of a chapter, and the parser merges them into a single content string.

---

### Changes

- Added multi-page chapter fetching logic in the fetcher
- Updated parser to handle merging multiple pages into one chapter
- Moved ad patterns into `ADS` and improved `_is_ad_line` filtering

---

### Motivation

Shuhaige chapters were incomplete because only the first page was parsed.

This fix ensures full content is captured and cleaned, improving reading quality.

---

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
