### PR TITLE
feat(cli): add interactive mode and new prompts module

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -188,6 +188,8 @@ user_prompt = "请翻译成中文：{text}"
 
   * 支持登录
 
+* [台灣小說網](https://twkan.com/)
+
 * [笔仙阁](https://m.bixiange.me/)
 
 * [52书库](https://www.52shuku.net/)

--- a/src/novel_downloader/apps/cli/commands/export.py
+++ b/src/novel_downloader/apps/cli/commands/export.py
@@ -8,7 +8,7 @@ novel_downloader.apps.cli.commands.export
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
-from novel_downloader.apps.cli import ui
+from novel_downloader.apps.cli import prompts, ui
 from novel_downloader.apps.constants import DOWNLOAD_SUPPORT_SITES
 from novel_downloader.apps.utils import load_or_init_config
 from novel_downloader.infra.config import ConfigAdapter
@@ -77,7 +77,7 @@ class ExportCmd(Command):
         # site selection
         if not site:
             book_ids = []  # ignore passed-in ids when site is not specified
-            site = cls._prompt_select_site(raw_dir)
+            site = prompts.select_site(raw_dir)
             if site is None:
                 ui.warn(t("No site selected."))
                 return
@@ -90,7 +90,7 @@ class ExportCmd(Command):
 
         # book selection
         if not book_ids:
-            selected = cls._prompt_select_book_ids(raw_dir, site)
+            selected = prompts.select_books(raw_dir, site)
             if not selected:
                 ui.warn(t("No books selected."))
                 return
@@ -147,145 +147,3 @@ class ExportCmd(Command):
             result.append(BookConfig(book_id=book_id))
 
         return result
-
-    @staticmethod
-    def _prompt_select_site(raw_dir: Path, per_page: int = 10) -> str | None:
-        if not raw_dir.exists():
-            ui.error(t("Raw data directory does not exist: {p}").format(p=str(raw_dir)))
-            return None
-
-        site_dirs = sorted([p for p in raw_dir.iterdir() if p.is_dir()])
-        if not site_dirs:
-            ui.warn(t("No sites found under {p}.").format(p=str(raw_dir)))
-            return None
-
-        all_rows = [
-            [str(i), DOWNLOAD_SUPPORT_SITES.get(p.name, p.name), p.name]
-            for i, p in enumerate(site_dirs, 1)
-        ]
-
-        total = len(all_rows)
-        total_pages = max(1, (total + per_page - 1) // per_page)
-        page = 1
-
-        while True:
-            start = (page - 1) * per_page + 1
-            end = min(page * per_page, total)
-            page_rows = all_rows[start - 1 : end]
-
-            ui.render_table(
-                t("Available Sites · Page {page}/{total}").format(
-                    page=page, total=total_pages
-                ),
-                [t("#"), t("Site Name"), t("Site Key")],
-                page_rows,
-            )
-
-            numeric_choices = [str(i) for i in range(start, end + 1)]
-            nav_choices = []
-            if page < total_pages:
-                nav_choices.append("n")
-            if page > 1:
-                nav_choices.append("p")
-
-            choice = ui.prompt_choice(
-                t(
-                    "Enter a number, 'n' for next, 'p' for previous (press Enter to cancel)"  # noqa: E501
-                ),
-                numeric_choices + nav_choices,
-            )
-
-            if choice == "":
-                return None
-            if choice == "n" and page < total_pages:
-                page += 1
-                continue
-            if choice == "p" and page > 1:
-                page -= 1
-                continue
-            if choice in numeric_choices:
-                idx = int(choice)
-                return site_dirs[idx - 1].name
-
-    @staticmethod
-    def _prompt_select_book_ids(
-        raw_dir: Path, site: str, per_page: int = 10
-    ) -> list[str]:
-        import json
-
-        site_dir = raw_dir / site
-        if not site_dir.exists():
-            ui.error(t("Site directory does not exist: {p}").format(p=str(site_dir)))
-            return []
-
-        book_dirs = sorted([p for p in site_dir.iterdir() if p.is_dir()])
-        if not book_dirs:
-            ui.warn(t("No books found under site '{site}'.").format(site=site))
-            return []
-
-        all_rows = []
-        for i, p in enumerate(book_dirs, 1):
-            book_id = p.name
-            book_name, author = "", ""
-            info_path = p / "book_info.raw.json"
-            if info_path.exists():
-                try:
-                    with info_path.open("r", encoding="utf-8") as f:
-                        meta = json.load(f)
-                        book_name = str(meta.get("book_name", "") or "")
-                        author = str(meta.get("author", "") or "")
-                except Exception:
-                    ui.warn(t("Failed to read metadata for {bid}").format(bid=book_id))
-            all_rows.append([str(i), book_id, book_name, author])
-
-        total = len(all_rows)
-        total_pages = max(1, (total + per_page - 1) // per_page)
-        page = 1
-
-        while True:
-            start = (page - 1) * per_page + 1
-            end = min(page * per_page, total)
-            page_rows = all_rows[start - 1 : end]
-
-            ui.render_table(
-                t("Available Books for {site} · Page {page}/{total}").format(
-                    site=site, page=page, total=total_pages
-                ),
-                [t("#"), t("Book ID"), t("Title"), t("Author")],
-                page_rows,
-            )
-
-            numeric_choices = [str(i) for i in range(start, end + 1)]
-            nav_choices = []
-            if page < total_pages:
-                nav_choices.append("n")
-            if page > 1:
-                nav_choices.append("p")
-
-            choice = ui.prompt_choice(
-                t(
-                    "Enter numbers (e.g. 1,3,5), 'a' for all, 'n' next, 'p' previous (Enter to cancel)"  # noqa: E501
-                ),
-                numeric_choices + nav_choices + ["a"],
-            )
-
-            if choice == "":
-                return []
-            if choice == "a":
-                return [p.name for p in book_dirs]
-            if choice == "n" and page < total_pages:
-                page += 1
-                continue
-            if choice == "p" and page > 1:
-                page -= 1
-                continue
-            if "," in choice or choice in numeric_choices:
-                try:
-                    idxs = sorted({int(s) for s in choice.split(",") if s.strip()})
-                except ValueError:
-                    ui.warn(t("Invalid input."))
-                    continue
-                if any(i < 1 or i > len(book_dirs) for i in idxs):
-                    ui.warn(t("One or more indices out of range."))
-                    continue
-                return [book_dirs[i - 1].name for i in idxs]

--- a/src/novel_downloader/apps/cli/interactive.py
+++ b/src/novel_downloader/apps/cli/interactive.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.apps.cli.interactive
+-------------------------------------
+
+An interactive CLI mode for novel_downloader.
+
+Provides a guided workflow for:
+  1. Searching for novels
+  2. Downloading novels (by URL or by site/book ID)
+  3. Exporting downloaded novels
+"""
+
+import asyncio
+from pathlib import Path
+
+from novel_downloader.apps.cli import prompts, ui
+from novel_downloader.apps.utils import load_or_init_config
+from novel_downloader.infra.config import ConfigAdapter
+from novel_downloader.infra.i18n import t
+from novel_downloader.libs.book_url_resolver import resolve_book_url
+from novel_downloader.plugins import registrar
+from novel_downloader.plugins.search import search
+from novel_downloader.schemas import BookConfig
+
+from .ui_adapters import (
+    CLIDownloadUI,
+    CLIExportUI,
+    CLILoginUI,
+    CLIProcessUI,
+)
+
+
+def start_interactive() -> None:
+    """Entry point for interactive mode."""
+    ui.info(t("Starting interactive mode..."))
+
+    config_data = load_or_init_config()
+    if config_data is None:
+        return
+
+    adapter = ConfigAdapter(config=config_data)
+    ui.setup_logging(console_level=adapter.get_log_level())
+
+    plugins_cfg = adapter.get_plugins_config()
+    if plugins_cfg.get("enable_local_plugins"):
+        registrar.enable_local_plugins(
+            plugins_cfg.get("local_plugins_path"),
+            override=plugins_cfg.get("override_builtins", False),
+        )
+
+    while True:
+        choice = prompts.select_main_action()
+        if choice == "":
+            ui.info(t("Goodbye!"))
+            break
+
+        if choice == "1":
+            asyncio.run(_interactive_search(adapter))
+        elif choice == "2":
+            asyncio.run(_interactive_download(adapter))
+        elif choice == "3":
+            _interactive_export(adapter)
+        else:
+            ui.warn(t("Invalid choice. Please try again."))
+
+
+async def _interactive_search(adapter: ConfigAdapter) -> None:
+    """Search for a book across supported sites and optionally download it."""
+    keyword = ui.prompt(t("Enter a keyword to search"))
+    if not keyword:
+        ui.warn(t("No keyword entered."))
+        return
+
+    with ui.status(t("Searching for '{keyword}'...").format(keyword=keyword)):
+        try:
+            results = await search(keyword=keyword)
+        except Exception as e:
+            ui.error(t("Search failed: {err}").format(err=e))
+            return
+
+    chosen = prompts.select_search_result(results)
+    if chosen is None:
+        ui.warn(t("Cancelled."))
+        return
+
+    site = chosen["site"]
+    book = BookConfig(book_id=chosen["book_id"])
+
+    if ui.confirm(t("Do you want to download this book now?"), default=True):
+        await _do_download(adapter, site, book)
+
+
+async def _interactive_download(adapter: ConfigAdapter) -> None:
+    """Download a book directly by URL or Site/Book ID."""
+    ui.info(t("Download Mode"))
+
+    mode = ui.prompt_choice(
+        t("Enter 'u' for URL or 'i' for Site + Book ID (Enter to cancel)"),
+        ["u", "i", ""],
+    )
+    if mode == "":
+        ui.warn(t("Cancelled."))
+        return
+
+    if mode == "u":
+        url = ui.prompt(t("Enter the book URL"))
+        if not url:
+            ui.warn(t("No URL provided."))
+            return
+        info = resolve_book_url(url)
+        if not info:
+            ui.error(t("Unable to parse book URL."))
+            return
+        site = info["site_key"]
+        book = info["book"]
+    else:
+        site = ui.prompt(t("Enter site key"))
+        book_id = ui.prompt(t("Enter book ID"))
+        if not site or not book_id:
+            ui.warn(t("Incomplete information."))
+            return
+        book = BookConfig(book_id=book_id)
+
+    await _do_download(adapter, site, book)
+
+
+async def _do_download(adapter: ConfigAdapter, site: str, book: BookConfig) -> None:
+    """Shared routine to handle login + download + process."""
+    client = registrar.get_client(site, config=adapter.get_client_config(site))
+    login_ui = CLILoginUI()
+    download_ui = CLIDownloadUI()
+
+    try:
+        async with client:
+            if adapter.get_login_required(site):
+                success = await client.login(
+                    ui=login_ui,
+                    login_cfg=adapter.get_login_config(site),
+                )
+                if not success:
+                    ui.warn(t("Login failed."))
+                    return
+
+            await client.download(book, ui=download_ui)
+
+    except ValueError as e:
+        ui.warn(
+            t("'{site}' is currently not supported: {err}").format(site=site, err=e)
+        )
+        return
+    except Exception as e:
+        ui.error(
+            t("Error while downloading from {site}: {err}").format(site=site, err=e)
+        )
+        return
+
+    process_ui = CLIProcessUI()
+    client.process(
+        book,
+        processors=adapter.get_processor_configs(site),
+        ui=process_ui,
+    )
+
+    if ui.confirm(t("Do you want to export this book now?"), default=True):
+        _interactive_export(adapter, site=site, book=book)
+
+
+def _interactive_export(
+    adapter: ConfigAdapter, site: str | None = None, book: BookConfig | None = None
+) -> None:
+    """Export novels interactively."""
+    raw_cfg = adapter.get_config().get("general") or {}
+    raw_dir = Path(raw_cfg.get("raw_data_dir", "./raw_data"))
+
+    if not site:
+        site = prompts.select_site(raw_dir)
+        if not site:
+            ui.warn(t("No site selected."))
+            return
+
+    if not book:
+        book_ids = prompts.select_books(raw_dir, site)
+        if not book_ids:
+            ui.warn(t("No books selected."))
+            return
+        book = BookConfig(book_id=book_ids[0])
+
+    formats = adapter.get_export_fmt(site)
+    client = registrar.get_client(site)
+    export_ui = CLIExportUI()
+
+    ui.info(
+        t("Exporting book '{book_id}' in formats: {fmt}").format(
+            book_id=book.book_id, fmt=", ".join(formats)
+        )
+    )
+
+    try:
+        client.export(
+            book,
+            cfg=adapter.get_exporter_config(site),
+            formats=formats,
+            ui=export_ui,
+        )
+        ui.success(t("Export completed successfully."))
+    except Exception as e:
+        ui.error(t("Export failed: {err}").format(err=e))

--- a/src/novel_downloader/apps/cli/main.py
+++ b/src/novel_downloader/apps/cli/main.py
@@ -14,12 +14,19 @@ from novel_downloader.infra.i18n import t
 
 def cli_main() -> None:
     parser = argparse.ArgumentParser(description=t("Novel Downloader CLI tool."))
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
 
     for cmd in commands:
         cmd.register(subparsers)
 
     args = parser.parse_args()
+
+    if args.command is None:
+        from novel_downloader.apps.cli.interactive import start_interactive
+
+        start_interactive()
+        return
+
     if hasattr(args, "func"):
         try:
             args.func(args)

--- a/src/novel_downloader/apps/cli/prompts.py
+++ b/src/novel_downloader/apps/cli/prompts.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.apps.cli.prompts
+---------------------------------
+"""
+
+__all__ = [
+    "select_books",
+    "select_main_action",
+    "select_search_result",
+    "select_site",
+]
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from novel_downloader.apps.cli import ui
+from novel_downloader.apps.constants import DOWNLOAD_SUPPORT_SITES, SEARCH_SUPPORT_SITES
+from novel_downloader.infra.i18n import t
+from novel_downloader.schemas import SearchResult
+
+
+def select_main_action() -> str:
+    """
+    Display the main interactive menu and return user's choice.
+    """
+    ui.render_table(
+        t("Main Menu"),
+        [t("#"), t("Action")],
+        [
+            ["1", t("Search for novels")],
+            ["2", t("Download novel (by URL or Site/Book ID)")],
+            ["3", t("Export previously downloaded novels")],
+            ["", t("Exit")],
+        ],
+    )
+
+    choice = ui.prompt_choice(
+        t("Select an action"),
+        ["1", "2", "3"],
+    )
+    return choice
+
+
+def select_site(raw_dir: Path, per_page: int = 10) -> str | None:
+    if not raw_dir.exists():
+        ui.error(t("Raw data directory does not exist: {p}").format(p=str(raw_dir)))
+        return None
+
+    site_dirs = sorted([p for p in raw_dir.iterdir() if p.is_dir()])
+    if not site_dirs:
+        ui.warn(t("No sites found under {p}.").format(p=str(raw_dir)))
+        return None
+
+    all_rows = [
+        [str(i), DOWNLOAD_SUPPORT_SITES.get(p.name, p.name), p.name]
+        for i, p in enumerate(site_dirs, 1)
+    ]
+
+    total = len(all_rows)
+    total_pages = max(1, (total + per_page - 1) // per_page)
+    page = 1
+
+    while True:
+        start = (page - 1) * per_page + 1
+        end = min(page * per_page, total)
+        page_rows = all_rows[start - 1 : end]
+
+        ui.render_table(
+            t("Available Sites · Page {page}/{total}").format(
+                page=page, total=total_pages
+            ),
+            [t("#"), t("Site Name"), t("Site Key")],
+            page_rows,
+        )
+
+        numeric_choices = [str(i) for i in range(start, end + 1)]
+        nav_choices = []
+        if page < total_pages:
+            nav_choices.append("n")
+        if page > 1:
+            nav_choices.append("p")
+
+        choice = ui.prompt_choice(
+            t(
+                "Enter a number, 'n' for next, 'p' for previous (press Enter to cancel)"  # noqa: E501
+            ),
+            numeric_choices + nav_choices,
+        )
+
+        if choice == "":
+            return None
+        if choice == "n" and page < total_pages:
+            page += 1
+            continue
+        if choice == "p" and page > 1:
+            page -= 1
+            continue
+        if choice in numeric_choices:
+            idx = int(choice)
+            return site_dirs[idx - 1].name
+
+
+def select_books(raw_dir: Path, site: str, per_page: int = 10) -> list[str]:
+    import json
+
+    site_dir = raw_dir / site
+    if not site_dir.exists():
+        ui.error(t("Site directory does not exist: {p}").format(p=str(site_dir)))
+        return []
+
+    book_dirs = sorted([p for p in site_dir.iterdir() if p.is_dir()])
+    if not book_dirs:
+        ui.warn(t("No books found under site '{site}'.").format(site=site))
+        return []
+
+    all_rows = []
+    for i, p in enumerate(book_dirs, 1):
+        book_id = p.name
+        book_name, author = "", ""
+        info_path = p / "book_info.raw.json"
+        if info_path.exists():
+            try:
+                with info_path.open("r", encoding="utf-8") as f:
+                    meta = json.load(f)
+                    book_name = str(meta.get("book_name", "") or "")
+                    author = str(meta.get("author", "") or "")
+            except Exception:
+                ui.warn(t("Failed to read metadata for {bid}").format(bid=book_id))
+        all_rows.append([str(i), book_id, book_name, author])
+
+    total = len(all_rows)
+    total_pages = max(1, (total + per_page - 1) // per_page)
+    page = 1
+
+    while True:
+        start = (page - 1) * per_page + 1
+        end = min(page * per_page, total)
+        page_rows = all_rows[start - 1 : end]
+
+        ui.render_table(
+            t("Available Books for {site} · Page {page}/{total}").format(
+                site=site, page=page, total=total_pages
+            ),
+            [t("#"), t("Book ID"), t("Title"), t("Author")],
+            page_rows,
+        )
+
+        numeric_choices = [str(i) for i in range(start, end + 1)]
+        nav_choices = []
+        if page < total_pages:
+            nav_choices.append("n")
+        if page > 1:
+            nav_choices.append("p")
+
+        choice = ui.prompt_choice(
+            t(
+                "Enter numbers (e.g. 1,3,5), 'a' for all, 'n' next, 'p' previous (Enter to cancel)"  # noqa: E501
+            ),
+            numeric_choices + nav_choices + ["a"],
+        )
+
+        if choice == "":
+            return []
+        if choice == "a":
+            return [p.name for p in book_dirs]
+        if choice == "n" and page < total_pages:
+            page += 1
+            continue
+        if choice == "p" and page > 1:
+            page -= 1
+            continue
+        if "," in choice or choice in numeric_choices:
+            try:
+                idxs = sorted({int(s) for s in choice.split(",") if s.strip()})
+            except ValueError:
+                ui.warn(t("Invalid input."))
+                continue
+            if any(i < 1 or i > len(book_dirs) for i in idxs):
+                ui.warn(t("One or more indices out of range."))
+                continue
+            return [book_dirs[i - 1].name for i in idxs]
+
+
+def select_search_result(
+    results: Sequence[SearchResult],
+    per_page: int = 10,
+) -> SearchResult | None:
+    """
+    Show results in pages and let user select by global index.
+    """
+    if not results:
+        ui.warn(t("No results found."))
+        return None
+
+    total = len(results)
+    total_pages = max(1, (total + per_page - 1) // per_page)
+    page = 1
+
+    columns = [
+        t("#"),
+        t("Title"),
+        t("Author"),
+        t("Latest"),
+        t("Updated"),
+        t("Site Name"),
+        t("Book ID"),
+    ]
+    all_rows = [
+        [
+            str(i),
+            r["title"],
+            r["author"],
+            r["latest_chapter"],
+            r["update_date"],
+            SEARCH_SUPPORT_SITES.get(r["site"], r["site"]),
+            r["book_id"],
+        ]
+        for i, r in enumerate(results, 1)
+    ]
+
+    while True:
+        start = (page - 1) * per_page + 1
+        end = min(page * per_page, total)
+
+        page_rows = all_rows[start - 1 : end]
+
+        ui.render_table(
+            t("Search Results · Page {page}/{total_pages}").format(
+                page=page, total_pages=total_pages
+            ),
+            columns,
+            page_rows,
+        )
+
+        numeric_choices = [str(i) for i in range(start, end + 1)]
+        nav_choices = []
+        if page < total_pages:
+            nav_choices.append("n")
+        if page > 1:
+            nav_choices.append("p")
+
+        choice = ui.prompt_choice(
+            t(
+                "Enter a number, 'n' for next, 'p' for previous (press Enter to cancel)"  # noqa: E501
+            ),
+            numeric_choices + nav_choices,
+        )
+
+        if choice == "":
+            return None  # cancel
+        if choice == "n" and page < total_pages:
+            page += 1
+            continue
+        if choice == "p" and page > 1:
+            page -= 1
+            continue
+        if choice in numeric_choices:
+            idx = int(choice)
+            return results[idx - 1]

--- a/src/novel_downloader/apps/utils.py
+++ b/src/novel_downloader/apps/utils.py
@@ -12,7 +12,7 @@ from novel_downloader.infra.config import copy_default_config, load_config
 from novel_downloader.infra.i18n import t
 
 
-def load_or_init_config(config_path: Path | None) -> dict[str, Any] | None:
+def load_or_init_config(config_path: Path | None = None) -> dict[str, Any] | None:
     try:
         return load_config(config_path)
     except FileNotFoundError:

--- a/src/novel_downloader/infra/config/adapter.py
+++ b/src/novel_downloader/infra/config/adapter.py
@@ -44,6 +44,9 @@ class ConfigAdapter:
         """
         self._config: dict[str, Any] = dict(config)
 
+    def get_config(self) -> dict[str, Any]:
+        return self._config
+
     def get_fetcher_config(self, site: str) -> FetcherConfig:
         """
         Build a :class:`novel_downloader.models.FetcherConfig` by resolving fields

--- a/src/novel_downloader/libs/fontocr/__init__.py
+++ b/src/novel_downloader/libs/fontocr/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-novel_downloader.infra.fontocr
-------------------------------
+novel_downloader.libs.fontocr
+-----------------------------
 
 Font-based OCR utilities for parsing and restoring obfuscated text.
 """

--- a/src/novel_downloader/libs/fontocr/core.py
+++ b/src/novel_downloader/libs/fontocr/core.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-novel_downloader.infra.fontocr.core
------------------------------------
+novel_downloader.libs.fontocr.core
+----------------------------------
 
 This class provides utility methods for optical character recognition (OCR),
 primarily used for decrypting custom font encryption.

--- a/src/novel_downloader/libs/fontocr/loader.py
+++ b/src/novel_downloader/libs/fontocr/loader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-novel_downloader.infra.fontocr.loader
--------------------------------------
+novel_downloader.libs.fontocr.loader
+------------------------------------
 
 Lazily load the FontOCR class.
 """

--- a/src/novel_downloader/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/src/novel_downloader/locales/zh_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: novel-downloader 2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-29 23:43-0400\n"
+"POT-Creation-Date: 2025-11-01 21:15-0400\n"
 "PO-Revision-Date: 2025-09-22 22:43-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: src\novel_downloader\apps\utils.py:22
 #, python-brace-format
 msgid "No config found at {path}."
-msgstr "在 {path} 未找到配置文件。"
+msgstr "在 {path} 未找到配置文件"
 
 #: src\novel_downloader\apps\utils.py:24
 msgid "Would you like to create a default config?"
@@ -28,20 +28,270 @@ msgstr "是否要创建一个默认配置文件？"
 #: src\novel_downloader\apps\utils.py:27
 #, python-brace-format
 msgid "Created default config at {path}."
-msgstr "已在 {path} 创建默认配置文件。"
+msgstr "已在 {path} 创建默认配置文件"
 
 #: src\novel_downloader\apps\utils.py:32
 msgid "Cannot continue without a config file."
-msgstr "没有配置文件，无法继续执行。"
+msgstr "没有配置文件，无法继续执行"
 
 #: src\novel_downloader\apps\utils.py:36
 #, python-brace-format
 msgid "Failed to load configuration: {err}"
-msgstr "加载配置失败：{err}"
+msgstr "加载配置失败: {err}"
+
+#: src\novel_downloader\apps\cli\interactive.py:36
+msgid "Starting interactive mode..."
+msgstr "正在启动交互模式..."
+
+#: src\novel_downloader\apps\cli\interactive.py:55
+msgid "Goodbye!"
+msgstr "再见！"
+
+#: src\novel_downloader\apps\cli\interactive.py:65
+msgid "Invalid choice. Please try again."
+msgstr "无效的选择，请重试"
+
+#: src\novel_downloader\apps\cli\interactive.py:70
+msgid "Enter a keyword to search"
+msgstr "请输入搜索关键字"
+
+#: src\novel_downloader\apps\cli\interactive.py:72
+msgid "No keyword entered."
+msgstr "未输入任何关键字"
+
+#: src\novel_downloader\apps\cli\interactive.py:75
+#: src\novel_downloader\apps\cli\commands\search.py:84
+#, python-brace-format
+msgid "Searching for '{keyword}'..."
+msgstr "正在搜索 '{keyword}'..."
+
+#: src\novel_downloader\apps\cli\interactive.py:79
+#, python-brace-format
+msgid "Search failed: {err}"
+msgstr "搜索失败: {err}"
+
+#: src\novel_downloader\apps\cli\interactive.py:84
+#: src\novel_downloader\apps\cli\interactive.py:103
+msgid "Cancelled."
+msgstr "已取消"
+
+#: src\novel_downloader\apps\cli\interactive.py:90
+msgid "Do you want to download this book now?"
+msgstr "是否立即下载此书？"
+
+#: src\novel_downloader\apps\cli\interactive.py:96
+msgid "Download Mode"
+msgstr "下载模式"
+
+#: src\novel_downloader\apps\cli\interactive.py:99
+msgid "Enter 'u' for URL or 'i' for Site + Book ID (Enter to cancel)"
+msgstr "输入 'u' 以使用 URL，或输入 'i' 以使用站点与书籍 ID (回车取消)"
+
+#: src\novel_downloader\apps\cli\interactive.py:107
+msgid "Enter the book URL"
+msgstr "请输入书籍 URL"
+
+#: src\novel_downloader\apps\cli\interactive.py:109
+msgid "No URL provided."
+msgstr "未提供 URL"
+
+#: src\novel_downloader\apps\cli\interactive.py:113
+msgid "Unable to parse book URL."
+msgstr "无法解析书籍 URL"
+
+#: src\novel_downloader\apps\cli\interactive.py:118
+msgid "Enter site key"
+msgstr "请输入站点键值"
+
+#: src\novel_downloader\apps\cli\interactive.py:119
+msgid "Enter book ID"
+msgstr "请输入书籍 ID"
+
+#: src\novel_downloader\apps\cli\interactive.py:121
+msgid "Incomplete information."
+msgstr "信息不完整"
+
+#: src\novel_downloader\apps\cli\interactive.py:142
+msgid "Login failed."
+msgstr "登录失败"
+
+#: src\novel_downloader\apps\cli\interactive.py:148
+#: src\novel_downloader\apps\cli\commands\download.py:165
+#: src\novel_downloader\apps\cli\commands\search.py:122
+#, python-brace-format
+msgid "'{site}' is currently not supported: {err}"
+msgstr "暂不支持站点 '{site}': {err}"
+
+#: src\novel_downloader\apps\cli\interactive.py:152
+#, python-brace-format
+msgid "Error while downloading from {site}: {err}"
+msgstr "从站点 {site} 下载时出错: {err}"
+
+#: src\novel_downloader\apps\cli\interactive.py:163
+msgid "Do you want to export this book now?"
+msgstr "是否立即导出此书？"
+
+#: src\novel_downloader\apps\cli\interactive.py:177
+#: src\novel_downloader\apps\cli\commands\export.py:82
+msgid "No site selected."
+msgstr "未选择任何站点"
+
+#: src\novel_downloader\apps\cli\interactive.py:183
+#: src\novel_downloader\apps\cli\commands\export.py:95
+msgid "No books selected."
+msgstr "未选择任何书籍"
+
+#: src\novel_downloader\apps\cli\interactive.py:192
+#, python-brace-format
+msgid "Exporting book '{book_id}' in formats: {fmt}"
+msgstr "正在导出书籍 '{book_id}', 格式: {fmt}"
+
+#: src\novel_downloader\apps\cli\interactive.py:204
+msgid "Export completed successfully."
+msgstr "导出完成"
+
+#: src\novel_downloader\apps\cli\interactive.py:206
+#, python-brace-format
+msgid "Export failed: {err}"
+msgstr "导出失败: {err}"
 
 #: src\novel_downloader\apps\cli\main.py:16
 msgid "Novel Downloader CLI tool."
 msgstr "小说下载器 CLI 工具"
+
+#: src\novel_downloader\apps\cli\prompts.py:28
+msgid "Main Menu"
+msgstr "主菜单"
+
+#: src\novel_downloader\apps\cli\prompts.py:29
+#: src\novel_downloader\apps\cli\prompts.py:73
+#: src\novel_downloader\apps\cli\prompts.py:145
+#: src\novel_downloader\apps\cli\prompts.py:201
+msgid "#"
+msgstr "序号"
+
+#: src\novel_downloader\apps\cli\prompts.py:29
+msgid "Action"
+msgstr "操作"
+
+#: src\novel_downloader\apps\cli\prompts.py:31
+msgid "Search for novels"
+msgstr "搜索小说"
+
+#: src\novel_downloader\apps\cli\prompts.py:32
+msgid "Download novel (by URL or Site/Book ID)"
+msgstr "下载小说 (通过 URL 或 站点+书籍 ID)"
+
+#: src\novel_downloader\apps\cli\prompts.py:33
+msgid "Export previously downloaded novels"
+msgstr "导出已下载的小说"
+
+#: src\novel_downloader\apps\cli\prompts.py:34
+msgid "Exit"
+msgstr "退出"
+
+#: src\novel_downloader\apps\cli\prompts.py:39
+msgid "Select an action"
+msgstr "请选择操作"
+
+#: src\novel_downloader\apps\cli\prompts.py:47
+#, python-brace-format
+msgid "Raw data directory does not exist: {p}"
+msgstr "原始数据目录不存在: {p}"
+
+#: src\novel_downloader\apps\cli\prompts.py:52
+#, python-brace-format
+msgid "No sites found under {p}."
+msgstr "在 {p} 下未找到任何站点"
+
+#: src\novel_downloader\apps\cli\prompts.py:70
+#, python-brace-format
+msgid "Available Sites · Page {page}/{total}"
+msgstr "可用站点 · 第 {page}/{total} 页"
+
+#: src\novel_downloader\apps\cli\prompts.py:73
+#: src\novel_downloader\apps\cli\prompts.py:206
+msgid "Site Name"
+msgstr "站点名称"
+
+#: src\novel_downloader\apps\cli\prompts.py:73
+msgid "Site Key"
+msgstr "站点键"
+
+#: src\novel_downloader\apps\cli\prompts.py:86
+#: src\novel_downloader\apps\cli\prompts.py:245
+msgid "Enter a number, 'n' for next, 'p' for previous (press Enter to cancel)"
+msgstr "输入序号选择，'n' 下一页，'p' 上一页（回车取消）"
+
+#: src\novel_downloader\apps\cli\prompts.py:109
+#, python-brace-format
+msgid "Site directory does not exist: {p}"
+msgstr "站点目录不存在: {p}"
+
+#: src\novel_downloader\apps\cli\prompts.py:114
+#, python-brace-format
+msgid "No books found under site '{site}'."
+msgstr "在站点 '{site}' 下未找到任何书籍"
+
+#: src\novel_downloader\apps\cli\prompts.py:129
+#, python-brace-format
+msgid "Failed to read metadata for {bid}"
+msgstr "读取 {bid} 的元数据失败"
+
+#: src\novel_downloader\apps\cli\prompts.py:142
+#, python-brace-format
+msgid "Available Books for {site} · Page {page}/{total}"
+msgstr "{site} 的可用书籍 · 第 {page}/{total} 页"
+
+#: src\novel_downloader\apps\cli\prompts.py:145
+#: src\novel_downloader\apps\cli\prompts.py:207
+#: src\novel_downloader\apps\web\pages\download.py:72
+#: src\novel_downloader\apps\web\pages\progress.py:140
+msgid "Book ID"
+msgstr "书籍 ID"
+
+#: src\novel_downloader\apps\cli\prompts.py:145
+#: src\novel_downloader\apps\cli\prompts.py:202
+#: src\novel_downloader\apps\web\pages\search.py:302
+msgid "Title"
+msgstr "书名"
+
+#: src\novel_downloader\apps\cli\prompts.py:145
+#: src\novel_downloader\apps\cli\prompts.py:203
+#: src\novel_downloader\apps\web\pages\search.py:303
+msgid "Author"
+msgstr "作者"
+
+#: src\novel_downloader\apps\cli\prompts.py:158
+msgid ""
+"Enter numbers (e.g. 1,3,5), 'a' for all, 'n' next, 'p' previous (Enter to "
+"cancel)"
+msgstr "输入序号 (如 1,3,5)，'a' 全选，'n' 下一页，'p' 上一页（回车取消）"
+
+#: src\novel_downloader\apps\cli\prompts.py:177
+msgid "Invalid input."
+msgstr "输入无效"
+
+#: src\novel_downloader\apps\cli\prompts.py:180
+msgid "One or more indices out of range."
+msgstr "一个或多个索引超出范围"
+
+#: src\novel_downloader\apps\cli\prompts.py:193
+msgid "No results found."
+msgstr "未找到结果"
+
+#: src\novel_downloader\apps\cli\prompts.py:204
+msgid "Latest"
+msgstr "最新章节"
+
+#: src\novel_downloader\apps\cli\prompts.py:205
+msgid "Updated"
+msgstr "更新时间"
+
+#: src\novel_downloader\apps\cli\prompts.py:229
+#, python-brace-format
+msgid "Search Results · Page {page}/{total_pages}"
+msgstr "搜索结果 · 第 {page}/{total_pages} 页"
 
 #: src\novel_downloader\apps\cli\ui_adapters.py:21
 #, python-brace-format
@@ -55,7 +305,7 @@ msgstr "下载进度"
 #: src\novel_downloader\apps\cli\ui_adapters.py:34
 #, python-brace-format
 msgid "Book {book_id} downloaded."
-msgstr "书籍 {book_id} 下载完成。"
+msgstr "书籍 {book_id} 下载完成"
 
 #: src\novel_downloader\apps\cli\ui_adapters.py:42
 #, python-brace-format
@@ -70,12 +320,12 @@ msgstr "书籍 {book_id} 已成功导出为 {format}"
 #: src\novel_downloader\apps\cli\ui_adapters.py:55
 #, python-brace-format
 msgid "Failed to export book {book_id} as {format}: {err}"
-msgstr "书籍 {book_id} 导出为 {format} 失败：{err}"
+msgstr "书籍 {book_id} 导出为 {format} 失败: {err}"
 
 #: src\novel_downloader\apps\cli\ui_adapters.py:62
 #, python-brace-format
 msgid "Export format '{format}' is not supported for book {book_id}."
-msgstr "书籍 {book_id} 不支持导出格式 '{format}'。"
+msgstr "书籍 {book_id} 不支持导出格式 '{format}'"
 
 #: src\novel_downloader\apps\cli\ui_adapters.py:82
 msgid "Description"
@@ -108,11 +358,11 @@ msgstr "该字段为必填项，请输入值"
 #: src\novel_downloader\apps\cli\ui_adapters.py:117
 msgid ""
 "Login failed: please check your cookies or account credentials and try again."
-msgstr "登录失败：请检查您的 Cookies 或账户凭据后重试"
+msgstr "登录失败: 请检查您的 Cookies 或账户凭据后重试"
 
 #: src\novel_downloader\apps\cli\ui_adapters.py:122
 msgid "Login successful."
-msgstr "登录成功。"
+msgstr "登录成功"
 
 #: src\novel_downloader\apps\cli\ui_adapters.py:135
 #, python-brace-format
@@ -167,11 +417,11 @@ msgstr "确定要删除所有本地数据吗？"
 
 #: src\novel_downloader\apps\cli\commands\clean.py:59
 msgid "Clean operation cancelled."
-msgstr "清理操作已取消。"
+msgstr "清理操作已取消"
 
 #: src\novel_downloader\apps\cli\commands\clean.py:73
 msgid "No clean option specified."
-msgstr "未指定清理选项。"
+msgstr "未指定清理选项"
 
 #: src\novel_downloader\apps\cli\commands\clean.py:83
 #, python-brace-format
@@ -186,12 +436,12 @@ msgstr "已删除 {path}"
 #: src\novel_downloader\apps\cli\commands\clean.py:92
 #, python-brace-format
 msgid "Failed to delete {path}: {err}"
-msgstr "删除 {path} 失败：{err}"
+msgstr "删除 {path} 失败: {err}"
 
 #: src\novel_downloader\apps\cli\commands\clean.py:95
 #, python-brace-format
 msgid "Not found: {path}"
-msgstr "未找到：{path}"
+msgstr "未找到: {path}"
 
 #: src\novel_downloader\apps\cli\commands\config.py:27
 msgid "Manage application configuration and settings"
@@ -208,12 +458,12 @@ msgstr "如果文件已存在则强制覆盖"
 #: src\novel_downloader\apps\cli\commands\config.py:62
 #, python-brace-format
 msgid "Overwriting existing file: {filename}"
-msgstr "正在覆盖已存在的文件：{filename}"
+msgstr "正在覆盖已存在的文件: {filename}"
 
 #: src\novel_downloader\apps\cli\commands\config.py:68
 #, python-brace-format
 msgid "File already exists: {filename}"
-msgstr "文件已存在：{filename}"
+msgstr "文件已存在: {filename}"
 
 #: src\novel_downloader\apps\cli\commands\config.py:73
 #, python-brace-format
@@ -223,17 +473,17 @@ msgstr "是否要覆盖 {filename}？"
 #: src\novel_downloader\apps\cli\commands\config.py:80
 #, python-brace-format
 msgid "Skipped: {filename}"
-msgstr "已跳过：{filename}"
+msgstr "已跳过: {filename}"
 
 #: src\novel_downloader\apps\cli\commands\config.py:85
 #, python-brace-format
 msgid "Copied: {filename}"
-msgstr "已复制：{filename}"
+msgstr "已复制: {filename}"
 
 #: src\novel_downloader\apps\cli\commands\config.py:88
 #, python-brace-format
 msgid "Failed to copy {filename}: {err}"
-msgstr "复制 {filename} 失败：{err}"
+msgstr "复制 {filename} 失败: {err}"
 
 #: src\novel_downloader\apps\cli\commands\config.py:97
 msgid "Set the interface language."
@@ -251,12 +501,12 @@ msgstr "设置并保存自定义 TOML 配置文件"
 #: src\novel_downloader\apps\cli\commands\config.py:124
 #, python-brace-format
 msgid "Configuration file saved from {path}."
-msgstr "配置文件已保存：{path}"
+msgstr "配置文件已保存: {path}"
 
 #: src\novel_downloader\apps\cli\commands\config.py:127
 #, python-brace-format
 msgid "Failed to save configuration file: {err}"
-msgstr "保存配置文件失败：{err}"
+msgstr "保存配置文件失败: {err}"
 
 #: src\novel_downloader\apps\cli\commands\download.py:29
 msgid "Download novels by book ID or URL."
@@ -272,7 +522,7 @@ msgstr "来源站点标识（若省略且提供了 URL，将自动检测）"
 
 #: src\novel_downloader\apps\cli\commands\download.py:41
 #: src\novel_downloader\apps\cli\commands\export.py:44
-#: src\novel_downloader\apps\cli\commands\search.py:44
+#: src\novel_downloader\apps\cli\commands\search.py:43
 msgid "Path to the configuration file"
 msgstr "配置文件路径"
 
@@ -293,7 +543,7 @@ msgstr "跳过导出步骤（仅下载）"
 #: src\novel_downloader\apps\cli\commands\download.py:61
 #: src\novel_downloader\apps\cli\commands\export.py:37
 msgid "Output format(s) (default: config)"
-msgstr "输出格式（默认：配置文件）"
+msgstr "输出格式（默认: 配置文件）"
 
 #: src\novel_downloader\apps\cli\commands\download.py:76
 msgid "No --site provided; detecting site from URL..."
@@ -307,36 +557,30 @@ msgstr "省略 --site 时应只提供一个 URL 参数（收到 {n} 个）"
 #: src\novel_downloader\apps\cli\commands\download.py:89
 #, python-brace-format
 msgid "Could not resolve site and book from URL: {url}"
-msgstr "无法从 URL 解析站点和书籍：{url}"
+msgstr "无法从 URL 解析站点和书籍: {url}"
 
 #: src\novel_downloader\apps\cli\commands\download.py:103
 #, python-brace-format
 msgid "Resolved URL to site '{site}' with book ID '{book_id}'."
-msgstr "已解析 URL：站点 '{site}'，书籍 ID '{book_id}'"
+msgstr "已解析 URL: 站点 '{site}'，书籍 ID '{book_id}'"
 
 #: src\novel_downloader\apps\cli\commands\download.py:112
 #: src\novel_downloader\apps\cli\commands\export.py:86
 #, python-brace-format
 msgid "Using site: {site}"
-msgstr "使用站点：{site}"
+msgstr "使用站点: {site}"
 
 #: src\novel_downloader\apps\cli\commands\download.py:120
 #, python-brace-format
 msgid "Failed to read book IDs from configuration: {err}"
-msgstr "从配置读取书籍 ID 失败：{err}"
+msgstr "从配置读取书籍 ID 失败: {err}"
 
 #: src\novel_downloader\apps\cli\commands\download.py:127
 msgid "No book IDs provided. Exiting."
 msgstr "未提供书籍 ID，已退出"
 
-#: src\novel_downloader\apps\cli\commands\download.py:165
-#: src\novel_downloader\apps\cli\commands\search.py:123
-#, python-brace-format
-msgid "'{site}' is currently not supported: {err}"
-msgstr "暂不支持站点 '{site}': {err}"
-
 #: src\novel_downloader\apps\cli\commands\download.py:171
-#: src\novel_downloader\apps\cli\commands\search.py:129
+#: src\novel_downloader\apps\cli\commands\search.py:128
 #, python-brace-format
 msgid "Site error ({site}): {err}"
 msgstr "站点错误 ({site}): {err}"
@@ -359,149 +603,31 @@ msgstr "来源站点键（可选；若省略则交互式选择）"
 
 #: src\novel_downloader\apps\cli\commands\export.py:59
 msgid "Export stage (e.g. raw, cleaner). Defaults to last stage."
-msgstr "导出阶段 (例如 raw, cleaner) 默认使用最后阶段。"
+msgstr "导出阶段 (例如 raw, cleaner) 默认使用最后阶段"
 
-#: src\novel_downloader\apps\cli\commands\export.py:82
-msgid "No site selected."
-msgstr "未选择任何站点。"
-
-#: src\novel_downloader\apps\cli\commands\export.py:95
-msgid "No books selected."
-msgstr "未选择任何书籍。"
-
-#: src\novel_downloader\apps\cli\commands\export.py:154
-#, python-brace-format
-msgid "Raw data directory does not exist: {p}"
-msgstr "原始数据目录不存在：{p}"
-
-#: src\novel_downloader\apps\cli\commands\export.py:159
-#, python-brace-format
-msgid "No sites found under {p}."
-msgstr "在 {p} 下未找到任何站点。"
-
-#: src\novel_downloader\apps\cli\commands\export.py:177
-#, python-brace-format
-msgid "Available Sites · Page {page}/{total}"
-msgstr "可用站点 · 第 {page}/{total} 页"
-
-#: src\novel_downloader\apps\cli\commands\export.py:180
-#: src\novel_downloader\apps\cli\commands\export.py:254
-#: src\novel_downloader\apps\cli\commands\search.py:172
-msgid "#"
-msgstr "序号"
-
-#: src\novel_downloader\apps\cli\commands\export.py:180
-#: src\novel_downloader\apps\cli\commands\search.py:177
-msgid "Site Name"
-msgstr "站点名称"
-
-#: src\novel_downloader\apps\cli\commands\export.py:180
-msgid "Site Key"
-msgstr "站点键"
-
-#: src\novel_downloader\apps\cli\commands\export.py:193
-#: src\novel_downloader\apps\cli\commands\search.py:216
-msgid "Enter a number, 'n' for next, 'p' for previous (press Enter to cancel)"
-msgstr "输入序号选择，'n' 下一页，'p' 上一页（回车取消）"
-
-#: src\novel_downloader\apps\cli\commands\export.py:218
-#, python-brace-format
-msgid "Site directory does not exist: {p}"
-msgstr "站点目录不存在：{p}"
-
-#: src\novel_downloader\apps\cli\commands\export.py:223
-#, python-brace-format
-msgid "No books found under site '{site}'."
-msgstr "在站点 '{site}' 下未找到任何书籍。"
-
-#: src\novel_downloader\apps\cli\commands\export.py:238
-#, python-brace-format
-msgid "Failed to read metadata for {bid}"
-msgstr "读取 {bid} 的元数据失败"
-
-#: src\novel_downloader\apps\cli\commands\export.py:251
-#, python-brace-format
-msgid "Available Books for {site} · Page {page}/{total}"
-msgstr "{site} 的可用书籍 · 第 {page}/{total} 页"
-
-#: src\novel_downloader\apps\cli\commands\export.py:254
-#: src\novel_downloader\apps\cli\commands\search.py:178
-#: src\novel_downloader\apps\web\pages\download.py:72
-#: src\novel_downloader\apps\web\pages\progress.py:140
-msgid "Book ID"
-msgstr "书籍 ID"
-
-#: src\novel_downloader\apps\cli\commands\export.py:254
-#: src\novel_downloader\apps\cli\commands\search.py:173
-#: src\novel_downloader\apps\web\pages\search.py:302
-msgid "Title"
-msgstr "书名"
-
-#: src\novel_downloader\apps\cli\commands\export.py:254
-#: src\novel_downloader\apps\cli\commands\search.py:174
-#: src\novel_downloader\apps\web\pages\search.py:303
-msgid "Author"
-msgstr "作者"
-
-#: src\novel_downloader\apps\cli\commands\export.py:267
-msgid ""
-"Enter numbers (e.g. 1,3,5), 'a' for all, 'n' next, 'p' previous (Enter to "
-"cancel)"
-msgstr "输入序号 (如 1,3,5)，'a' 全选，'n' 下一页，'p' 上一页（回车取消）"
-
-#: src\novel_downloader\apps\cli\commands\export.py:286
-msgid "Invalid input."
-msgstr "输入无效。"
-
-#: src\novel_downloader\apps\cli\commands\export.py:289
-msgid "One or more indices out of range."
-msgstr "一个或多个索引超出范围。"
-
-#: src\novel_downloader\apps\cli\commands\search.py:31
+#: src\novel_downloader\apps\cli\commands\search.py:30
 msgid "Search for books across one or more sites."
 msgstr "在一个或多个站点搜索书籍"
 
-#: src\novel_downloader\apps\cli\commands\search.py:40
+#: src\novel_downloader\apps\cli\commands\search.py:39
 msgid "Restrict search to specific site key(s). Default: all sites."
-msgstr "限制搜索范围为指定站点（默认：全部站点）"
+msgstr "限制搜索范围为指定站点（默认: 全部站点）"
 
-#: src\novel_downloader\apps\cli\commands\search.py:42
+#: src\novel_downloader\apps\cli\commands\search.py:41
 msgid "Search keyword"
 msgstr "搜索关键词"
 
-#: src\novel_downloader\apps\cli\commands\search.py:52
+#: src\novel_downloader\apps\cli\commands\search.py:51
 msgid "Maximum number of total results"
 msgstr "最大总结果数"
 
-#: src\novel_downloader\apps\cli\commands\search.py:59
+#: src\novel_downloader\apps\cli\commands\search.py:58
 msgid "Maximum number of results per site (default: 10)"
-msgstr "每个站点的最大结果数（默认：10）"
+msgstr "每个站点的最大结果数（默认: 10）"
 
-#: src\novel_downloader\apps\cli\commands\search.py:66
+#: src\novel_downloader\apps\cli\commands\search.py:65
 msgid "Request timeout in seconds (default: 5.0)"
-msgstr "请求超时时间（秒，默认：5.0）"
-
-#: src\novel_downloader\apps\cli\commands\search.py:85
-#, python-brace-format
-msgid "Searching for '{keyword}'..."
-msgstr "正在搜索 '{keyword}'..."
-
-#: src\novel_downloader\apps\cli\commands\search.py:164
-msgid "No results found."
-msgstr "未找到结果"
-
-#: src\novel_downloader\apps\cli\commands\search.py:175
-msgid "Latest"
-msgstr "最新章节"
-
-#: src\novel_downloader\apps\cli\commands\search.py:176
-msgid "Updated"
-msgstr "更新时间"
-
-#: src\novel_downloader\apps\cli\commands\search.py:200
-#, python-brace-format
-msgid "Search Results · Page {page}/{total_pages}"
-msgstr "搜索结果 · 第 {page}/{total_pages} 页"
+msgstr "请求超时时间（秒，默认: 5.0）"
 
 #: src\novel_downloader\apps\web\components\navigation.py:38
 #: src\novel_downloader\apps\web\pages\search.py:293
@@ -570,7 +696,7 @@ msgstr "添加到下载队列"
 #: src\novel_downloader\apps\web\pages\download.py:132
 #, python-brace-format
 msgid "Site: {site}"
-msgstr "站点：{site}"
+msgstr "站点: {site}"
 
 #: src\novel_downloader\apps\web\pages\download.py:133
 #, python-brace-format
@@ -579,7 +705,7 @@ msgstr "书籍 ID: {bid}"
 
 #: src\novel_downloader\apps\web\pages\download.py:138
 msgid "Parsing failed: The link may not be supported or is invalid"
-msgstr "解析失败：该链接可能不受支持或格式不正确"
+msgstr "解析失败: 该链接可能不受支持或格式不正确"
 
 #: src\novel_downloader\apps\web\pages\download.py:147
 msgid "Please enter a novel URL"
@@ -846,8 +972,8 @@ msgstr "请在已登录状态下从浏览器开发者工具复制 Cookies"
 
 #, python-brace-format
 #~ msgid "Failed to download {book_id}: {err}"
-#~ msgstr "书籍 {book_id} 下载失败：{err}"
+#~ msgstr "书籍 {book_id} 下载失败: {err}"
 
 #, python-brace-format
 #~ msgid "Error processing {book_id} at stage '{stage}': {err}"
-#~ msgstr "处理书籍 {book_id} 的阶段 {stage} 时出错：{err}"
+#~ msgstr "处理书籍 {book_id} 的阶段 {stage} 时出错: {err}"

--- a/src/novel_downloader/plugins/sites/esjzone/parser.py
+++ b/src/novel_downloader/plugins/sites/esjzone/parser.py
@@ -14,7 +14,7 @@ from urllib.parse import unquote
 
 from lxml import etree, html
 
-from novel_downloader.infra.fontocr import get_font_ocr
+from novel_downloader.libs.fontocr import get_font_ocr
 from novel_downloader.plugins.base.parser import BaseParser
 from novel_downloader.plugins.registry import registrar
 from novel_downloader.schemas import (

--- a/src/novel_downloader/plugins/sites/qidian/parser.py
+++ b/src/novel_downloader/plugins/sites/qidian/parser.py
@@ -17,9 +17,9 @@ from typing import Any, TypedDict
 from lxml import html
 
 from novel_downloader.infra.cookies import get_cookie_value
-from novel_downloader.infra.fontocr import get_font_ocr
 from novel_downloader.infra.jsbridge import get_decryptor
 from novel_downloader.infra.paths import DATA_DIR
+from novel_downloader.libs.fontocr import get_font_ocr
 from novel_downloader.libs.textutils import truncate_half_lines
 from novel_downloader.plugins.base.parser import BaseParser
 from novel_downloader.plugins.registry import registrar

--- a/src/novel_downloader/plugins/sites/qqbook/parser.py
+++ b/src/novel_downloader/plugins/sites/qqbook/parser.py
@@ -16,8 +16,8 @@ from typing import Any, TypedDict
 
 from lxml import html
 
-from novel_downloader.infra.fontocr import get_font_ocr
 from novel_downloader.infra.jsbridge import get_decryptor
+from novel_downloader.libs.fontocr import get_font_ocr
 from novel_downloader.plugins.base.parser import BaseParser
 from novel_downloader.plugins.registry import registrar
 from novel_downloader.schemas import (

--- a/src/novel_downloader/plugins/sites/sfacg/parser.py
+++ b/src/novel_downloader/plugins/sites/sfacg/parser.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from lxml import html
 
-from novel_downloader.infra.fontocr import get_font_ocr
+from novel_downloader.libs.fontocr import get_font_ocr
 from novel_downloader.plugins.base.parser import BaseParser
 from novel_downloader.plugins.registry import registrar
 from novel_downloader.schemas import (

--- a/src/novel_downloader/plugins/sites/xiguashuwu/parser.py
+++ b/src/novel_downloader/plugins/sites/xiguashuwu/parser.py
@@ -18,9 +18,9 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 from lxml import html
 
-from novel_downloader.infra.fontocr import get_font_ocr
 from novel_downloader.infra.http_defaults import DEFAULT_USER_HEADERS
 from novel_downloader.infra.paths import XIGUASHUWU_MAP_PATH
+from novel_downloader.libs.fontocr import get_font_ocr
 from novel_downloader.plugins.base.parser import BaseParser
 from novel_downloader.plugins.registry import registrar
 from novel_downloader.schemas import (


### PR DESCRIPTION
### Description

This PR introduces a new **interactive CLI mode** and a dedicated **`prompts` module** that centralizes all user interaction logic (e.g., site selection, book selection, search result selection).

Previously, prompt-related code was embedded in individual command classes such as `export` and `search`.

---

### Changes

- Added `novel_downloader.apps.cli.interactive` module providing:
  - Guided interactive workflow for **Search**, **Download**, and **Export**.
- Introduced new `novel_downloader.apps.cli.prompts` module containing:
  - Reusable prompt helpers: `select_site`, `select_books`, and `select_search_result`.
  - Centralized logic for interactive menus such as `select_main_action()`.
- Refactored existing command classes (`ExportCmd`, etc.) to use these new prompt utilities.
- Unified UI feedback and pagination behavior across all CLI interactions.

---

### Motivation

- Simplifies CLI maintenance by decoupling prompt logic from individual commands.
- Enables a cohesive, user-friendly **interactive mode** that reuses the same prompt functions.
- Establishes a consistent and extensible interface for future interactive features.
- Improves readability and code organization across the CLI layer.

---

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that improves structure or readability)
