### PR TITLE
chore(release): bump version to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.5.0 (2025-11-11)
+
+### Feat
+
+- **sites**: add new book sources and update media structure (#127)
+- **fetcher**: support optional backend via aiohttp / httpx / curl_cffi (#126)
+- **cli**: add interactive mode and new prompts module (#125)
+- **plugins**: merge downloader and exporter, add translator and new site supports (#124)
+- **scripts**: extract site data test flow from pytest into standalone script (#114)
+
 ## v2.4.1 (2025-10-18)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ omit = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.4.1"
+version = "2.5.0"
 version_files = [
     "src/novel_downloader/__init__.py"
 ]

--- a/src/novel_downloader/__init__.py
+++ b/src/novel_downloader/__init__.py
@@ -6,7 +6,7 @@ novel_downloader
 Core package for the Novel Downloader project.
 """
 
-__version__ = "2.4.1"
+__version__ = "2.5.0"
 
 __author__ = "Saudade Z"
 __email__ = "saudadez217@gmail.com"


### PR DESCRIPTION
### Description

Bump version from 2.4.1 to 2.5.0 for release.

---

### Changes

- Version bump only
