### PR TITLE
refactor(libs): enhance html_builder with custom font support

### DIFF
--- a/src/novel_downloader/libs/html_builder/constants.py
+++ b/src/novel_downloader/libs/html_builder/constants.py
@@ -8,6 +8,7 @@ CHAPTER_DIR = "chapters"
 CSS_DIR = "css"
 JS_DIR = "js"
 MEDIA_DIR = "media"
+FONT_DIR = "fonts"
 
 IMAGE_MEDIA_EXTS: dict[str, str] = {
     "image/png": "png",
@@ -17,25 +18,36 @@ IMAGE_MEDIA_EXTS: dict[str, str] = {
     "image/webp": "webp",
 }
 
-INDEX_TEMPLATE = """\
+FONT_FORMAT_MAP = {
+    "ttf": "truetype",
+    "otf": "opentype",
+    "woff": "woff",
+    "woff2": "woff2",
+}
+
+DEFAULT_FONT_FALLBACK_STACK = (
+    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+)
+
+INDEX_TEMPLATE = f"""\
 <!DOCTYPE html>
-<html lang="{lang}">
+<html lang="{{lang}}">
 <head>
   <meta charset="utf-8">
-  <title>{book_name}</title>
-  <link rel="stylesheet" href="css/index.css">
-  <script defer src="js/main.js"></script>
+  <title>{{book_name}}</title>
+  <link rel="stylesheet" href="{CSS_DIR}/index.css">
+  <script defer src="{JS_DIR}/main.js"></script>
 </head>
 <body>
   <div id="progress-bar"></div>
 
   <header>
-    {header}
+    {{header}}
   </header>
 
   <main class="toc">
     <h2>目录</h2>
-    {toc_html}
+    {{toc_html}}
   </main>
 
   <!-- Floating controls -->
@@ -49,30 +61,38 @@ INDEX_TEMPLATE = """\
 </html>
 """
 
-CHAPTER_TEMPLATE = """\
+FONT_FACE_TEMPLATE = """\
+@font-face {{
+  font-family: "{family}";
+  src: url("{url}") format("{format}");
+}}
+"""
+
+CHAPTER_TEMPLATE = f"""\
 <!DOCTYPE html>
-<html lang="{lang}">
+<html lang="{{lang}}">
 <head>
   <meta charset="utf-8">
-  <title>{title}</title>
-  <link rel="stylesheet" href="../css/chapter.css">
-  <script defer src="../js/main.js"></script>
+  <title>{{title}}</title>
+  <link rel="stylesheet" href="../{CSS_DIR}/chapter.css">
+  <script defer src="../{JS_DIR}/main.js"></script>
+  {{font_styles}}
 </head>
 <body>
   <div id="progress-bar"></div>
 
-  <h1>{title}</h1>
+  <h1 class="chapter-title">{{title}}</h1>
   <div class="chapter-content">
-    {content}
+    {{content}}
   </div>
 
   <nav class="chapter-nav"
-       data-prev="{prev_link}"
-       data-next="{next_link}"
+       data-prev="{{prev_link}}"
+       data-next="{{next_link}}"
        data-menu="../index.html">
-    <a id="prev-link" href="{prev_link}" class="nav-button">← 上一章</a>
+    <a id="prev-link" href="{{prev_link}}" class="nav-button">← 上一章</a>
     <a id="menu-link" href="../index.html" class="nav-button">☰ 目录</a>
-    <a id="next-link" href="{next_link}" class="nav-button">下一章 →</a>
+    <a id="next-link" href="{{next_link}}" class="nav-button">下一章 →</a>
   </nav>
 
   <!-- Floating controls -->

--- a/src/novel_downloader/libs/html_builder/models.py
+++ b/src/novel_downloader/libs/html_builder/models.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from html import escape
 
-from .constants import CHAPTER_TEMPLATE
+from .constants import (
+    CHAPTER_TEMPLATE,
+    DEFAULT_FONT_FALLBACK_STACK,
+    FONT_DIR,
+    FONT_FACE_TEMPLATE,
+    FONT_FORMAT_MAP,
+)
 
 
 @dataclass(frozen=True)
@@ -19,10 +25,39 @@ class HtmlImage:
 
 
 @dataclass(frozen=True)
+class HtmlFont:
+    filename: str
+    data: bytes
+    family: str
+    selectors: tuple[str, ...] = field(default_factory=tuple)
+
+    def _font_format(self) -> str:
+        """Best-effort guess for CSS `format()` from filename extension."""
+        ext = self.filename.rsplit(".", 1)[-1].lower()
+        return FONT_FORMAT_MAP.get(ext, "truetype")
+
+    @property
+    def effective_selectors(self) -> tuple[str, ...]:
+        """Use user-provided selectors, or default to '.chapter-content'."""
+        if self.selectors:
+            return self.selectors
+        return (".chapter-content",)
+
+    def build_css(self, *, font_url_prefix: str) -> str:
+        """Build the CSS content for this font."""
+        return FONT_FACE_TEMPLATE.format(
+            family=self.family,
+            url=f"{font_url_prefix}{self.filename}",
+            format=self._font_format(),
+        )
+
+
+@dataclass(frozen=True)
 class HtmlChapter:
     filename: str
     title: str
     content: str
+    fonts: list[HtmlFont] = field(default_factory=list)
 
     def to_html(
         self,
@@ -31,16 +66,48 @@ class HtmlChapter:
         prev_link: str = "",
         next_link: str = "",
     ) -> str:
-        """
-        Generate the HTML for a chapter.
-        """
+        """Generate the HTML for a chapter."""
         return CHAPTER_TEMPLATE.format(
             lang=lang,
             title=escape(self.title),
             prev_link=prev_link,
             next_link=next_link,
             content=self.content,
+            font_styles=self._build_font_styles(),
         )
+
+    def _collect_selectors(self) -> dict[str, list[str]]:
+        """
+        Collects mapping of selector -> list of font-family names.
+
+        e.g. ``{".chapter-content": ["MyObfA", "MyObfB"]}``
+        """
+        mapping: dict[str, list[str]] = {}
+        for font in self.fonts:
+            for sel in font.effective_selectors:
+                mapping.setdefault(sel, []).append(font.family)
+        return mapping
+
+    def _build_font_styles(self) -> str:
+        """Build the <style> block for all fonts in this chapter."""
+        if not self.fonts:
+            return ""
+        blocks: list[str] = ["<style>"]
+
+        # Emit all @font-face blocks first
+        prefix = f"../{FONT_DIR}/"
+        for font in self.fonts:
+            blocks.append(font.build_css(font_url_prefix=prefix))
+
+        # Build selector -> font-family rules
+        selector_map = self._collect_selectors()
+        for selector, families in selector_map.items():
+            family_stack = ", ".join(f'"{name}"' for name in families)
+            family_stack += f", {DEFAULT_FONT_FALLBACK_STACK}"
+            blocks.append(f"{selector} {{ font-family: {family_stack}; }}")
+
+        blocks.append("</style>")
+        return "\n".join(blocks)
 
 
 @dataclass

--- a/src/novel_downloader/libs/html_builder/utils.py
+++ b/src/novel_downloader/libs/html_builder/utils.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-"""
-novel_downloader.libs.html_builder.utils
-----------------------------------------
-"""


### PR DESCRIPTION
### Description

Refactor the `html_builder` module in `libs` to enable custom font support during HTML generation.

Includes cleanup of several internal implementations to improve clarity, structure, and maintainability.

---

### Changes

- Added support for embedding or referencing custom fonts in `HtmlBuilder`
- Refactored `html_builder` internals for improved readability and structure
- Improved implementation details for cleaner and more idiomatic logic
- Minor internal cleanup and consistency improvements

---

### Motivation

Custom font support improves styling flexibility for generated HTML output and aligns the module with modern presentation requirements.

---

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that improves structure or readability)
