### PR TITLE
chore(release): bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v3.1.0 (2025-11-24)
+
+### Feat
+
+- **client**: add cleanup APIs and CLI clean subcommands with documentation (#143)
+
+### Refactor
+
+- **core**: reorganize sessions, split fontocr, rewrite jsbridge, and improve test coverage (#142)
+
 ## v3.0.1 (2025-11-22)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ omit = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "3.0.1"
+version = "3.1.0"
 version_files = [
     "src/novel_downloader/__init__.py"
 ]

--- a/src/novel_downloader/__init__.py
+++ b/src/novel_downloader/__init__.py
@@ -6,7 +6,7 @@ novel_downloader
 Core package for the Novel Downloader project.
 """
 
-__version__ = "3.0.1"
+__version__ = "3.1.0"
 
 __author__ = "Saudade Z"
 __email__ = "saudadez217@gmail.com"


### PR DESCRIPTION
### Description

Bump version from 3.0.1 to 3.1.0 for release.

---

### Changes

- Version bump only
