### PR TITLE
fix(cli): add missing --format option to search command

### DIFF
--- a/src/novel_downloader/apps/cli/commands/search.py
+++ b/src/novel_downloader/apps/cli/commands/search.py
@@ -64,11 +64,18 @@ class SearchCmd(Command):
             metavar="SECS",
             help=t("Request timeout in seconds (default: 5.0)"),
         )
+        parser.add_argument(
+            "--format",
+            nargs="+",
+            help=t("Output format(s) (default: config)"),
+        )
 
     @classmethod
     def run(cls, args: Namespace) -> None:
         sites: Sequence[str] | None = args.site or None
         keyword: str = args.keyword
+        formats: list[str] | None = args.format
+
         overall_limit = None if args.limit is None else max(1, args.limit)
         per_site_limit = max(1, args.site_limit)
         timeout = max(0.1, float(args.timeout))
@@ -144,7 +151,7 @@ class SearchCmd(Command):
                 client.export_book(
                     book,
                     cfg=adapter.get_exporter_config(site),
-                    formats=args.format or adapter.get_export_fmt(site),
+                    formats=formats or adapter.get_export_fmt(site),
                     ui=export_ui,
                 )
 


### PR DESCRIPTION
### Description

This PR fixes a CLI error where the `search` subcommand lacked the `--format` argument definition.

When running `novel-cli search` followed by export logic, the absence of this argument caused:

```
AttributeError: 'Namespace' object has no attribute 'format'
```

This PR adds the missing parameter and restores expected behavior.

---

### Changes

* Added the `--format` argument to the `search` subcommand.

---

### Motivation

The missing `--format` argument caused the `search` command to crash at runtime, making it impossible to directly export from search results.

---

### Related Issues

Fixes #146

---

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
