### PR TITLE
feat(export): add missing chapter placeholder rendering

### DIFF
--- a/docs/3-settings-schema.md
+++ b/docs/3-settings-schema.md
@@ -142,9 +142,10 @@ OCR 功能依赖 `PaddleOCR` 及其模型, 请参考安装指南:
 | 参数名                        | 类型         | 默认值                | 说明                                       |
 | ----------------------------- | ----------- | --------------------- | ------------------------------------------ |
 | `formats`                     | `list[str]` | `[]`                  | 输出格式                                    |
-| `append_timestamp`            | bool        | true                  | 输出文件名是否追加时间戳                     |
+| `render_missing_chapter`      | bool        | `true`                | 是否在导出时为缺失章节插入占位内容            |
+| `append_timestamp`            | bool        | `true`                | 输出文件名是否追加时间戳                     |
 | `filename_template`           | string      | `"{title}_{author}"`  | 文件名模板                                  |
-| `include_picture`             | bool        | true                  | 是否下载并嵌入章节中的图片 (可能增加文件体积) |
+| `include_picture`             | bool        | `true`                | 是否下载并嵌入章节中的图片 (可能增加文件体积) |
 
 #### 调试子节 `[general.debug]`
 

--- a/src/novel_downloader/infra/config/adapter.py
+++ b/src/novel_downloader/infra/config/adapter.py
@@ -137,6 +137,7 @@ class ConfigAdapter:
         out = {**g_out, **s_out}
 
         return ExporterConfig(
+            render_missing_chapter=out.get("render_missing_chapter", True),
             append_timestamp=out.get("append_timestamp", True),
             filename_template=out.get("filename_template", "{title}_{author}"),
             include_picture=out.get("include_picture", True),

--- a/src/novel_downloader/plugins/mixins/export_html.py
+++ b/src/novel_downloader/plugins/mixins/export_html.py
@@ -44,6 +44,14 @@ if TYPE_CHECKING:
         ) -> HtmlChapter:
             ...
 
+        def _xp_html_missing_chapter(
+            self,
+            *,
+            cid: str,
+            chap_title: str | None,
+        ) -> HtmlChapter:
+            ...
+
         def _xp_html_extras(self, extras: dict[str, Any]) -> str:
             ...
 
@@ -139,6 +147,12 @@ class ExportHtmlMixin:
 
                     ch = chap_map.get(cid)
                     if not ch:
+                        if cfg.render_missing_chapter:
+                            chapter_obj = self._xp_html_missing_chapter(
+                                cid=cid,
+                                chap_title=ch_title,
+                            )
+                            curr_vol.chapters.append(chapter_obj)
                         continue
 
                     chapter_obj = self._xp_html_chapter(
@@ -334,6 +348,28 @@ class ExportHtmlMixin:
             content=html_str,
             extra_content=extras_part,
             fonts=added_fonts,
+        )
+
+    def _xp_html_missing_chapter(
+        self,
+        *,
+        cid: str,
+        chap_title: str | None,
+    ) -> HtmlChapter:
+        """
+        Build a placeholder HTML chapter when content is missing
+        or inaccessible.
+        """
+        title = chap_title or f"Chapter {cid}"
+
+        html_str = "<p>本章内容暂不可用</p>"
+
+        return HtmlChapter(
+            filename=f"c{cid}.html",
+            title=title,
+            content=html_str,
+            extra_content="",
+            fonts=[],
         )
 
     def _xp_html_extras(self, extras: dict[str, Any]) -> str:

--- a/src/novel_downloader/plugins/mixins/export_txt.py
+++ b/src/novel_downloader/plugins/mixins/export_txt.py
@@ -42,6 +42,14 @@ if TYPE_CHECKING:
         def _xp_txt_chapter(self, chap_title: str | None, chap: ChapterDict) -> str:
             ...
 
+        def _xp_txt_missing_chapter(
+            self,
+            *,
+            cid: str,
+            chap_title: str | None,
+        ) -> str:
+            ...
+
         def _xp_txt_extras(self, extras: dict[str, Any]) -> str:
             ...
 
@@ -111,6 +119,13 @@ class ExportTxtMixin:
 
                     ch = chap_map.get(cid)
                     if not ch:
+                        if cfg.render_missing_chapter:
+                            parts.append(
+                                self._xp_txt_missing_chapter(
+                                    cid=cid,
+                                    chap_title=ch_title,
+                                )
+                            )
                         continue
 
                     parts.append(self._xp_txt_chapter(ch_title, ch))
@@ -255,6 +270,18 @@ class ExportTxtMixin:
             if extras_txt
             else f"{title_line}\n\n{body}\n\n"
         )
+
+    def _xp_txt_missing_chapter(
+        self,
+        *,
+        cid: str,
+        chap_title: str | None,
+    ) -> str:
+        """
+        Render a placeholder text block for missing or inaccessible chapters.
+        """
+        title = chap_title or f"Chapter {cid}"
+        return f"{title}\n\n本章内容暂不可用\n\n"
 
     def _xp_txt_extras(self, extras: dict[str, Any]) -> str:
         """

--- a/src/novel_downloader/resources/config/settings.sample.toml
+++ b/src/novel_downloader/resources/config/settings.sample.toml
@@ -27,6 +27,7 @@ formats = [
 #   "html",
 ]
 append_timestamp = true            # 在文件名中追加时间戳
+render_missing_chapter = true
 filename_template = "{title}_{author}"
 include_picture = true             # 是否附带书籍图片
 

--- a/src/novel_downloader/schemas/config.py
+++ b/src/novel_downloader/schemas/config.py
@@ -57,6 +57,7 @@ class ParserConfig:
 
 @dataclass
 class ExporterConfig:
+    render_missing_chapter: bool = True
     append_timestamp: bool = True
     filename_template: str = "{title}_{author}"
     include_picture: bool = True


### PR DESCRIPTION
### Description

This PR introduces a new configuration option `render_missing_chapter` and adds unified “missing chapter placeholder” support across TXT, EPUB, and HTML exporters.

When a chapter is missing (e.g., inaccessible, unsubscribed, or not downloaded), and `render_missing_chapter = true`, exporters now insert a placeholder section instead of silently skipping the chapter.

This improves readability, prevents unnoticed gaps, and provides a consistent experience across formats.

---

### Changes

* Added new config flag:
  **`render_missing_chapter: bool = true`** controls whether missing chapters should render a placeholder during export.
* Implemented `_xp_epub_missing_chapter()` helper and integrated the logic into:
  * `_export_volume_epub`
  * `_export_book_epub`
* Implemented `_xp_html_missing_chapter()` helper and integrated into:
  * `_export_book_html`
* Implemented `_xp_txt_missing_chapter()` helper and integrated into:
  * `_export_book_txt`
* Ensured all formats use a consistent placeholder structure:
  * Title line
  * "本章内容暂不可用" fallback text
* Updated export pipelines to correctly handle missing chapters instead of skipping them silently.

---

### Motivation

Previously, missing or inaccessible chapters were silently omitted during export.

For long novels or novels with many paid chapters, this often resulted in:

* unnoticed chapter gaps
* inconsistent reading experience
* difficulty identifying missing content

By adding explicit placeholder rendering, users can immediately see where chapters are unavailable, making the exported files more complete and easier to navigate.

---

### Related Issues

Fixes #148

---

### Type of change

* [x] New feature (non-breaking change which adds functionality)
