### PR TITLE
docs(readme): improve documentation structure and fix processors config typo

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,7 +43,7 @@ pip install -U novel-downloader
 Install with Web UI support:
 
 ```bash
-pip install novelkit[web-ui]
+pip install novel-downloader[web-ui]
 ```
 
 For all optional features (Web UI, OCR, image-to-text, extra backends, exporters, etc.), refer to the [Full Installation Guide](https://saudadez21.github.io/novel-downloader/guide/installation/).
@@ -53,11 +53,14 @@ For all optional features (Web UI, OCR, image-to-text, extra backends, exporters
 ## Quick Start (CLI)
 
 ```bash
+# Set preferred interface language
+novel-cli config set-lang en_US
+
 # Download a novel
-novelkit download https://www.example.com/book/123/
+novel-cli download https://www.example.com/book/123/
 
 # Using site + book ID
-novelkit download --site n23qb 12282
+novel-cli download --site n23qb 12282
 ```
 
 More examples: [CLI Examples](https://saudadez21.github.io/novel-downloader/guide/cli-examples/)

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,132 @@
+# novel-downloader
+
+[![PyPI](https://img.shields.io/pypi/v/novel-downloader.svg)](https://pypi.org/project/novel-downloader/)
+[![Python](https://img.shields.io/pypi/pyversions/novel-downloader.svg)](https://www.python.org/downloads/)
+[![CI](https://github.com/saudadez21/novel-downloader/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/saudadez21/novel-downloader/actions/workflows/ci.yml)
+[![Hits-of-Code](https://hitsofcode.com/github/saudadez21/novel-downloader?branch=main&label=Hits-of-Code)](https://hitsofcode.com/github/saudadez21/novel-downloader/view?branch=main&label=Hits-of-Code)
+
+[中文](./README.md) | [English](./README.en.md)
+
+Asynchronous, modular, and extensible toolkit for downloading and processing online novels.
+
+Supports resumable crawling, multi-format exporting, text processing pipeline, CLI, and optional Web UI.
+
+**Documentation**: [Project Documentation](https://saudadez21.github.io/novel-downloader/)
+
+**Requirements**: Python 3.11+ (development tested on Python 3.13)
+
+---
+
+## Features
+
+* Asynchronous and high-performance crawling
+* Resumable downloads (checkpoint recovery)
+* Pluggable HTTP backends: `aiohttp`, `httpx`, `curl_cffi`
+* Export to TXT, EPUB, and HTML
+* Text processing pipeline: ad removal, zh conversion, translation, etc.
+* Optional support for image chapters and obfuscated content
+* Plugin system for site parsers, exporters, and processing pipelines
+* CLI and optional Web GUI
+
+See the full feature list in the documentation: [Full Feature Overview](https://saudadez21.github.io/novel-downloader/)
+
+---
+
+## Installation
+
+Install the latest stable release:
+
+```bash
+pip install -U novel-downloader
+```
+
+Install with Web UI support:
+
+```bash
+pip install novelkit[web-ui]
+```
+
+For all optional features (Web UI, OCR, image-to-text, extra backends, exporters, etc.), refer to the [Full Installation Guide](https://saudadez21.github.io/novel-downloader/guide/installation/).
+
+---
+
+## Quick Start (CLI)
+
+```bash
+# Download a novel
+novelkit download https://www.example.com/book/123/
+
+# Using site + book ID
+novelkit download --site n23qb 12282
+```
+
+More examples: [CLI Examples](https://saudadez21.github.io/novel-downloader/guide/cli-examples/)
+
+---
+
+## Programmatic API
+
+```python
+import asyncio
+from novel_downloader.plugins import registrar
+from novel_downloader.schemas import BookConfig, ClientConfig
+
+async def main() -> None:
+    site = "n23qb"
+    book = BookConfig(book_id="12282")
+
+    cfg = ClientConfig(request_interval=0.5)
+    client = registrar.get_client(site, cfg)
+
+    async with client:
+        await client.download_book(book)
+
+    client.export_book(book, formats=["txt", "epub"])
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+More examples: [API Examples](https://saudadez21.github.io/novel-downloader/reference/api-examples/)
+
+---
+
+## Development
+
+```bash
+git clone https://github.com/saudadez21/novel-downloader.git
+cd novel-downloader
+
+pip install .
+# Optional:
+# pip install .[all]
+# pip install -e .[dev,all]
+```
+
+Translations (optional):
+
+```bash
+pip install babel
+pybabel compile -d src/novel_downloader/locales
+```
+
+PRs and issues are welcome.
+
+---
+
+## Notes
+
+* Site structures may change. If parsing issues occur, please open an issue or submit a patch.
+* Login support depends on site policies. Cookies or manual account setup may be required.
+* Configure request intervals responsibly to avoid rate limiting or IP blocking.
+
+---
+
+## Disclaimer
+
+This project is for learning and research purposes only.
+
+Do not use it for commercial or illegal activities.
+
+Users are responsible for complying with target sites' `robots.txt` and local regulations.
+The author assumes no liability for misuse.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install -U novel-downloader
 如需启用 Web GUI:
 
 ```bash
-pip install novelkit[web-ui]
+pip install novel-downloader[web-ui]
 ```
 
 如需启用其它可选功能 (Web UI、图片转文字、额外后端等), 请参见: [安装指南](https://saudadez21.github.io/novel-downloader/guide/installation/)
@@ -54,10 +54,10 @@ pip install novelkit[web-ui]
 
 ```bash
 # 下载一本小说
-novelkit download https://www.example.com/book/123/
+novel-cli download https://www.example.com/book/123/
 
 # 使用站点 + 书籍 ID
-novelkit download --site n23qb 12282
+novel-cli download --site n23qb 12282
 ```
 
 更多示例见: [CLI 使用示例](https://saudadez21.github.io/novel-downloader/guide/cli-examples/)

--- a/README.md
+++ b/README.md
@@ -5,50 +5,30 @@
 [![CI](https://github.com/saudadez21/novel-downloader/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/saudadez21/novel-downloader/actions/workflows/ci.yml)
 [![Hits-of-Code](https://hitsofcode.com/github/saudadez21/novel-downloader?branch=main&label=Hits-of-Code)](https://hitsofcode.com/github/saudadez21/novel-downloader/view?branch=main&label=Hits-of-Code)
 
+[中文](./README.md) | [English](./README.en.md)
+
 异步、可扩展的小说下载与处理工具包。
 
 支持断点续爬、多格式导出、文本处理流水线, 并提供 CLI 与可选 Web 界面。
 
-> 运行要求: **Python 3.11+** (开发环境: Python 3.13)
+**文档**: [项目文档](https://saudadez21.github.io/novel-downloader/)
+
+**运行要求**: Python 3.11+ (开发环境: Python 3.13)
+
+---
 
 ## 功能特性
 
-### 下载能力
+- **异步与高性能下载**
+- **可恢复下载 (断点续爬)**
+- **可插拔 HTTP 后端:** `aiohttp` / `httpx` / `curl_cffi`
+- **多格式导出:** TXT / EPUB / HTML
+- **文本处理流水线:** 去广告、繁简转换、自动翻译等
+- **图片章节与混淆章节支持 (可选)**
+- **插件系统:** 可扩展站点解析器、导出器、Pipeline 等
+- **CLI 与可选 Web GUI**
 
-* **可恢复下载**: 自动识别已完成的章节, 跳过重复抓取
-* **可插拔式 HTTP 后端**: 支持 `aiohttp` (默认)、`httpx`、`curl_cffi`
-
-### 多格式导出
-
-* **TXT**
-* **EPUB**
-* **HTML**
-
-### 内容清洗与增强
-
-* 广告与活动过滤
-  * 章节标题过滤
-  * 正文章节过滤
-* 文本处理流水线 (processors)
-  * 正则清理
-  * 繁简转换
-  * 机器翻译
-* 图片章节 / 混淆章节处理 (`image-utils` 可选)
-  * 原图下载
-  * 去水印
-  * 图像预处理
-  * 图片章节转文字 (需要 `enable_ocr`)
-  * 字体混淆还原 (需要 `enable_ocr`)
-
-### 扩展性
-
-* **插件系统**: 可扩展站点解析、文本处理器、导出器等能力
-* **可插拔式下载后端**: 适配不同 HTTP 客户端
-
-### 使用方式
-
-* **命令行 (CLI)**
-* **Web 图形界面 (GUI)**
+完整功能列表见: [功能总览](https://saudadez21.github.io/novel-downloader/)
 
 ---
 
@@ -60,95 +40,29 @@
 pip install -U novel-downloader
 ```
 
-如需启用字体解密 / 图片转文字 (`enable_ocr`), 请参见: [安装](docs/guide/installation.md)
+如需启用 Web GUI:
+
+```bash
+pip install novelkit[web-ui]
+```
+
+如需启用其它可选功能 (Web UI、图片转文字、额外后端等), 请参见: [安装指南](https://saudadez21.github.io/novel-downloader/guide/installation/)
 
 ---
 
-## 快速开始
-
-### 0. 设置语言 (可选)
+## 快速开始 (CLI)
 
 ```bash
-# 设置为中文
-novel-cli config set-lang zh_CN
+# 下载一本小说
+novelkit download https://www.example.com/book/123/
 
-# 设置为英文
-novel-cli config set-lang en_US
+# 使用站点 + 书籍 ID
+novelkit download --site n23qb 12282
 ```
 
-### 1. 初始化配置文件
+更多示例见: [CLI 使用示例](https://saudadez21.github.io/novel-downloader/guide/cli-examples/)
 
-```bash
-# 生成默认配置 ./settings.toml
-novel-cli config init
-```
-
-生成 `settings.toml` 后可编辑 `request_interval`、`book_ids` 等参数。
-
-详见: [settings.toml 配置说明](docs/guide/settings-reference.md)
-
-### 2. 命令行 (CLI)
-
-![cli_download](docs/assets/images/cli_download.gif)
-
-常用示例:
-
-```bash
-# 使用书籍页面 URL 自动解析并下载
-novel-cli download https://www.hetushu.com/book/5763/index.html
-
-# 使用配置文件中的 book_ids 启动下载
-novel-cli download --site qidian
-
-# 指定站点 + 书籍 ID 启动下载
-novel-cli download --site n23qb 12282
-```
-
-更多参数:
-
-```bash
-novel-cli --help
-novel-cli download --help
-```
-
-* 支持站点见: [支持站点列表](docs/supported-sites/index.md)
-* 更多示例见: [CLI 使用示例](docs/guide/cli-examples.md)
-* 运行中可使用 `CTRL+C` 取消任务
-
-### 3. 图形界面 (Web GUI)
-
-Web GUI 依赖额外组件 (如 NiceGUI), 默认不会随主程序一起安装。
-
-如需使用 Web 图形界面，请先安装对应的可选依赖。
-
-#### 3.1. 安装 Web GUI 依赖
-
-```bash
-pip install novel-downloader[web-ui]
-```
-
-> 若只需使用 CLI，可忽略此步骤。
-
-#### 3.2 启动 Web GUI
-
-```bash
-novel-web
-```
-
-如需提供局域网/外网访问 (请自行留意安全与网络环境):
-
-```bash
-novel-web --listen public
-```
-
-在运行过程中, 可使用 `CTRL+C` 停止服务。
-
-#### 3.3 更多资料
-
-* 支持站点见: [支持站点列表](docs/supported-sites/index.md)
-* 更多示例见: [WEB 使用示例](docs/guide/web-examples.md)
-
-### 4. 编程接口 (Programmatic API)
+## 编程接口 (Programmatic API)
 
 ```python
 import asyncio
@@ -167,49 +81,20 @@ async def main() -> None:
 
     # 在异步上下文中执行下载
     async with client:
-        await client.download(book)
+        await client.download_book(book)
 
     # 下载完成后执行导出操作
-    client.export(book, formats=["txt", "epub"])
+    client.export_book(book, formats=["txt", "epub"])
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
 
----
-
-## 文本处理 (`processors`)
-
-导出前可执行多阶段流水线处理, 包括:
-
-* 正则清理 (自定义去广告/去水印)
-* 繁简转换 (基于 [opencc-python](https://github.com/yichen0831/opencc-python))
-* 自动翻译 (支持 `google` / `edge` / `youdao` 等翻译器)
-* 文本纠错 (基于 [pycorrector](https://github.com/shibing624/pycorrector))
-
-处理顺序可配置, 并可生成中间产物用于导出
-
-> 详细配置示例见: [processors 配置](docs/guide/processors-reference.md)
+更多示例见: [API 示例](https://saudadez21.github.io/novel-downloader/reference/api-examples/)
 
 ---
 
-## 插件系统
-
-通过插件可扩展站点解析、文本处理器、导出器等能力。
-
-在 `settings.toml` 启用插件并实现对应接口后, 即可自动加入下载流程。
-
-示例: 新增站点解析器 (如 "刺猬猫" -> `ciweimao`), 实现目录页与章节页的抓取及解析方后即可直接下载:
-
-```bash
-novel-cli download --site ciweimao 123456
-```
-
-> 详见: [插件系统文档](docs/reference/plugins.md)
-
----
-
-## 从源码安装 (开发版)
+## 贡献与开发
 
 ```bash
 git clone https://github.com/saudadez21/novel-downloader.git
@@ -222,15 +107,10 @@ cd novel-downloader
 pip install .
 # 或安装带可选功能:
 # pip install .[all]
+# pip install -e .[dev,all]
 ```
 
----
-
-## 常见问题 / 排错
-
-* **网站结构变更导致解析失败**: 请更新至最新版或按站点文档自定义适配。
-* **需要登录的站点**: 参考 [复制 Cookies](docs/guide/copy-cookies.md)。
-* **导出文件位置**: 见 [文件保存](docs/guide/file-saving.md)。
+欢迎提交 Issue / PR。
 
 ---
 
@@ -244,5 +124,6 @@ pip install .
 
 ## 项目说明
 
-* 本项目仅供学习和研究使用, **不得**用于任何商业或违法用途; 请遵守目标网站的 `robots.txt` 及相关法律法规
+* 本项目仅供学习和研究使用, **不得**用于任何商业或违法用途
+* 请遵守目标网站的 `robots.txt` 及相关法律法规
 * 使用本项目产生的任何法律责任由使用者自行承担, 作者不承担相关责任

--- a/docs/guide/processors-reference.md
+++ b/docs/guide/processors-reference.md
@@ -28,7 +28,7 @@
 假设配置中写入:
 
 ```toml
-[[plugins.processors]]
+[[general.processors]]
 name = "cleaner"
 remove_invisible = true
 title_removes = "title-remove.json"

--- a/docs/guide/settings-reference.md
+++ b/docs/guide/settings-reference.md
@@ -284,15 +284,4 @@ enable_local_plugins = false
 override_builtins = false
 # 本地插件路径 (可选)
 local_plugins_path = "./novel_plugins"
-
-[[plugins.processors]]
-name = "cleaner"
-overwrite = false
-remove_invisible = true
-
-title_removes = "path/to/title-remove.json"
-title_replace = "path/to/title-replace.json"
-
-content_removes = "path/to/content-remove.json"
-content_replace = "path/to/content-replace.json"
 ```

--- a/docs/misc/todo.md
+++ b/docs/misc/todo.md
@@ -97,7 +97,7 @@ Parser 中已对常见第三方网站广告进行基础过滤, 需要继续排�
 
 计划扩展 `ProcessorProtocol`，新增翻译类处理器，用于在导出流程中对章节内容进行翻译。
 
-#### 在线翻译服务
+**在线翻译服务**
 
 * [有道翻译](https://www.youdao.com/)
 * [有道翻译 API](https://fanyi.youdao.com/openapi/)
@@ -109,7 +109,7 @@ Parser 中已对常见第三方网站广告进行基础过滤, 需要继续排�
 * [DeepL API](https://www.deepl.com/en/pro-api)
     * Python 库: [deepl](https://github.com/DeepLcom/deepl-python)
 
-#### 大模型 API 翻译
+**大模型 API 翻译**
 
 * OpenAI GPT 系列
 * Anthropic Claude
@@ -117,11 +117,11 @@ Parser 中已对常见第三方网站广告进行基础过滤, 需要继续排�
 * Google Gemini
 * 支持自定义 prompt 与目标语言
 
-#### 自建 / 本地翻译模型
+**自建 / 本地翻译模型**
 
 基于 `HuggingFace` / `Transformers` / `llama.cpp` / `Ollama` / `vLLM` 等框架。
 
-##### 可选模型
+可选模型:
 
 * [MarianMT](https://huggingface.co/docs/transformers/en/model_doc/marian)
 * [M2M-100](https://huggingface.co/docs/transformers/en/model_doc/m2m_100)
@@ -131,21 +131,21 @@ Parser 中已对常见第三方网站广告进行基础过滤, 需要继续排�
 * [aya-expanse-32b](https://huggingface.co/CohereLabs/aya-expanse-32b)
 * [Seed-X-7B](https://github.com/ByteDance-Seed/Seed-X-7B)
 
-#### 配置示例
+**配置示例**
 
 ```toml
-[[plugins.processors]]
+[[general.processors]]
 name = "translator.google"
 source = "zh"
 target = "en"
 
-[[plugins.processors]]
+[[general.processors]]
 name = "translator.deepl"
 api_key = "YOUR_KEY"
 source = "en"
 target = "fr"
 
-[[plugins.processors]]
+[[general.processors]]
 name = "translator.hf"
 model_path = "/models/Sakura-13B"
 system_prompt = "你是一个轻小说翻译模型，可以忠实翻译为简体中文。"

--- a/docs/notes/faloo_web.md
+++ b/docs/notes/faloo_web.md
@@ -19,11 +19,11 @@ date: 2025-11-17
 
 例如, 字符 `吧` 在被添加干扰边框后, 会渲染为:
 
-<img src="/assets/images/faloo/sample_1.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_1.png" width="270" style="image-rendering: pixelated;" />
 
 然而, 该方案有时会出现渲染错位的问题, 导致边框覆盖到文字主体, 从而影响正常阅读, 例如:
 
-<img src="/assets/images/faloo/sample_2.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_2.png" width="270" style="image-rendering: pixelated;" />
 
 ---
 
@@ -40,31 +40,31 @@ date: 2025-11-17
 
 最右侧方框示例:
 
-<img src="/assets/images/faloo/sample_1.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_1.png" width="270" style="image-rendering: pixelated;" />
 
 最左侧方框示例:
 
-<img src="/assets/images/faloo/sample_3.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_3.png" width="270" style="image-rendering: pixelated;" />
 
 可以看到, 在同为 18 × 18 像素的前提下, 左侧方框的最右侧多出了 2 列与左侧边框同色的像素, 用于与右侧方框重叠。
 
 在某些排版或渲染条件下, 边框可能会「压到」字符笔画内部, 例如:
 
-<img src="/assets/images/faloo/sample_4.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_4.png" width="270" style="image-rendering: pixelated;" />
 
 以及与相邻方框叠加的情况:
 
-<img src="/assets/images/faloo/sample_5.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_5.png" width="270" style="image-rendering: pixelated;" />
 
 另外, 不同行的方框在颜色选取上可能略有差异。
 
 例如, 在上述错位的示例中, 左侧边框的颜色与最开始示例中的边框颜色明显不同; 类似地, 还存在如下对比示例:
 
-<img src="/assets/images/faloo/sample_6.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_6.png" width="270" style="image-rendering: pixelated;" />
 
 以及:
 
-<img src="/assets/images/faloo/sample_7.png" width="270" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_7.png" width="270" style="image-rendering: pixelated;" />
 
 ---
 
@@ -350,11 +350,11 @@ def main() -> None:
 
 原图:
 
-<img src="/assets/images/faloo/sample_8.png" width="290" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_8.png" width="290" style="image-rendering: pixelated;" />
 
 处理后:
 
-<img src="/assets/images/faloo/sample_8_cleaned.png" width="290" style="image-rendering: pixelated;" />
+<img src="../../assets/images/faloo/sample_8_cleaned.png" width="290" style="image-rendering: pixelated;" />
 
 可以看到:
 

--- a/docs/notes/qidian_web.md
+++ b/docs/notes/qidian_web.md
@@ -188,51 +188,159 @@ async function decrypt(enContent, cuChapterId, fkp, fuid) {
 
 ### 1. CSS 级混淆分析
 
-字体显示顺序通常被 CSS 人为打乱, 结合 HTML 标签、属性与样式渲染可恢复原始内容。示例策略包括:
+在页面中, 字符的真实呈现顺序被 CSS 规则刻意打乱。
 
-* `font-size: 0`: 该元素不可见, 应跳过；
-* `scaleX(-1)`: 镜像翻转, 对内容无影响, 仅作为重建参考；
-* `::before` / `::after`: 在元素前后插入特定字符（如 `content: '遇'`）；
-* `content: attr(...)`: 插入指定属性值；
-* `order`: 用于重排段落或字符顺序, 需结合样式解析还原。
+通过分析 HTML 标签、属性以及相关伪元素样式, 可以重建文本的原始内容。常见的混淆策略包括:
+
+* `font-size: 0`: 元素内容不可见, 应在解析时忽略
+* `scaleX(-1)`: 对字符进行水平镜像, 不影响实际语义, 仅需在重建时还原为正常方向
+* `::before` / `::after`: 通过伪元素插入特定字符 (如 `content: '遇'`)
+* `content: attr(...)`: 将自定义属性中的内容注入渲染流
+* `order`: 配合 Flex 布局重排节点顺序, 需依据样式指令恢复文本原序
+
+**示例 CSS**:
+
+```css
+.sy-0 { font-size: 0; }
+ya1 { order: 1; }
+yf4 { order: 2; }
+y7r { order: 3; }
+yjq { order: 4; }
+yq3 { order: 5; }
+y87 { order: 6; }
+ypy { order: 7; }
+ylx { order: 8; }
+yfc { order: 9; }
+ypl { order: 10; }
+y3x { order: 11; }
+ys5 { order: 12; }
+y0v { order: 13; }
+ywp { order: 14; }
+y1p { order: 15; }
+.p1 ya1::after { content: '这'; }
+.p1 yf4::after { content: '儿'; }
+.p1 y7r::before { content: attr(ywda); }
+.p1 yjq::after { content: '真'; }
+.p1 yjq::first-letter { font-size: 0; }
+.p1 yq3::before { content: attr(ygmh); }
+.p1 y87::after { content: '一'; }
+.p1 ypy::before { content: attr(ya0u); }
+.p1 ylx::before { content: attr(yn2e); }
+.p1 yfc::after { content: '丽'; }
+.p1 ypl::before { content: attr(ylxl); }
+.p1 y3x::before { content: attr(y5jn); }
+.p1 ys5::after { content: '间'; }
+.p1 y0v::before { content: attr(ythw); }
+```
+
+**示例 HTML**:
+
+```html
+<p class="p1"><ylx yigi="也" yn2e="美"></ylx><ypl ylxl="的" yxry="开"></ypl><y3x y5jn="乡" ylyh="为"></y3x><yjq>种</yjq><y7r y6ak="学" ywda="可"></y7r><yfc></yfc><yq3 yiiv="国" ygmh="是"></yq3><ys5></ys5><yf4></yf4><ypy ya0u="个" yquq="要"></ypy><ya1></ya1><y87></y87><y0v ythw="！" yg84="了"></y0v></p>
+<p>在整个英格兰境<y class="sy-0">隐藏</y>内，我不相<y class="sy-0">测试</y>信我竟能找<y class="sy-0">藏字</y>到这样一个能与尘<y class="sy-0">藏字</y>世<y class="sy-0">藏字</y>的喧嚣完全隔绝的地<y class="sy-0">测试</y><y class="sy-0">藏字</y>方，<y class="sy-0">藏字</y>一个厌世者的<y class="sy-0">乱码</y>理想的<y class="sy-0">测试</y>天堂。</p>
+```
+
+**渲染效果示例**:
+
+<style>
+.sy-0 { font-size: 0; }
+ya1 { order: 1; }
+yf4 { order: 2; }
+y7r { order: 3; }
+yjq { order: 4; }
+yq3 { order: 5; }
+y87 { order: 6; }
+ypy { order: 7; }
+ylx { order: 8; }
+yfc { order: 9; }
+ypl { order: 10; }
+y3x { order: 11; }
+ys5 { order: 12; }
+y0v { order: 13; }
+ywp { order: 14; }
+y1p { order: 15; }
+.p1 { display: flex; }
+.p1 ya1::after { content: '这'; }
+.p1 yf4::after { content: '儿'; }
+.p1 y7r::before { content: attr(ywda); }
+.p1 yjq::after { content: '真'; }
+.p1 yjq::first-letter { font-size: 0; }
+.p1 yq3::before { content: attr(ygmh); }
+.p1 y87::after { content: '一'; }
+.p1 ypy::before { content: attr(ya0u); }
+.p1 ylx::before { content: attr(yn2e); }
+.p1 yfc::after { content: '丽'; }
+.p1 ypl::before { content: attr(ylxl); }
+.p1 y3x::before { content: attr(y5jn); }
+.p1 ys5::after { content: '间'; }
+.p1 y0v::before { content: attr(ythw); }
+</style>
+
+<p class="p1"><ylx yigi="也" yn2e="美"></ylx><ypl ylxl="的" yxry="开"></ypl><y3x y5jn="乡" ylyh="为"></y3x><yjq>种</yjq><y7r y6ak="学" ywda="可"></y7r><yfc></yfc><yq3 yiiv="国" ygmh="是"></yq3><ys5></ys5><yf4></yf4><ypy ya0u="个" yquq="要"></ypy><ya1></ya1><y87></y87><y0v ythw="！" yg84="了"></y0v></p>
+<p>在整个英格兰境<y class="sy-0">隐藏</y>内，我不相<y class="sy-0">测试</y>信我竟能找<y class="sy-0">藏字</y>到这样一个能与尘<y class="sy-0">藏字</y>世<y class="sy-0">藏字</y>的喧嚣完全隔绝的地<y class="sy-0">测试</y><y class="sy-0">藏字</y>方，<y class="sy-0">藏字</y>一个厌世者的<y class="sy-0">乱码</y>理想的<y class="sy-0">测试</y>天堂。</p>
 
 ### 2. 字体文件加密
 
-每章节使用两种加密字体:
+每个章节会加载两类加密字体, 用于隐藏真实字符编码:
 
-* `randomFont_str`: 每章节唯一, 字体编码动态变更；
-* `fixedFontWoff2_url`: 请求时从字体 "池" 中随机分配一份字体文件, 可能会在多个章节间复用。
+* `randomFont_str` (章节级动态字体): 每章唯一, 字体内部编码随机变换
+* `fixedFontWoff2_url` (字体池随机分发): 从服务器维护的字体池中随机返回一份字体文件, 同一字体可能被多个章节重复使用, 字体池会周期性轮换更新
 
-页面 CSS 示例:
+典型的 CSS 引用示例:
 
 ```css
 font-family: LIIBFYOT, HTEMPCHB, 'SourceHanSansSC-Regular', 'SourceHanSansCN-Regular', ...
 ```
 
-其中 `LIIBFYOT` 和 `HTEMPCHB` 为加密字体名称。由于真实字符并未直接展示, 需要通过以下手段还原真实内容。
+其中 `LIIBFYOT` 和 `HTEMPCHB` 即为加密字体, 由于页面使用的字体未直接暴露真实字形与原文字符之间的对应关系, 因此需要构建映射才能恢复正文内容。
 
 #### 字体还原思路与映射建立
 
-**初期阶段**
+> 字体由 [svg2ttf](https://github.com/fontello/svg2ttf) 生成, 即使对应同一字符, 不同版本字形仍存在细微差异。
+>
+> 因此, 最可行的方式是通过 OCR 自动识别字形并建立映射。
 
-* 使用类似字形的公开字体 (如 `SourceHanSans`) 进行模型微调；
-* 基于章节中的可见字符构建图像样本；
-* 利用 OCR (光学字符识别) 进行逐字识别 (单字图像, 无上下文)；
-* 若识别结果合理, 则可初步还原正文。
+**初期还原阶段**
 
-**自动构建字体映射**
+在缺乏历史映射数据的阶段, 可采用 OCR 的方式恢复章节文本:
 
-* 根据实际观察, 大多数章节在发布时间 **约一个月后** 退回为 "纯文本加密" 形式, 仅需解密正文即可获取明文 HTML。
-* 在此状态下, 若作者未修改就可以精确还原整章内容, 进一步与历史的加密版本进行比对, 从而建立 "字符形状 -> 字符" 之间的稳定映射关系。
-* 随着时间积累, 此映射数据集将逐渐完善, 可以进一步微调模型
+* 使用字形结构相似的公开字体 (如 `SourceHanSans`) 对模型进行轻量微调
+* 从页面中导出所有可见字符, 生成逐字图像样本
+* 使用 OCR 进行逐字识别 (单字识别, 无上下文)
+* 若模型识别结果稳定且逻辑合理, 可初步得到章节的明文内容
+
+**自动化建立持久字体映射**
+
+实际观察表明:
+
+* 大部分章节在发布 **约一个月后** 会回退为 **纯文本加密** (不再使用混淆字体)
+* 在这一状态下, 服务器返回的 HTML 已基本等价于纯文本, 只需解密正文即可获得准确明文
+
+在这种情况下, 可以进行高质量比对:
+
+* 获取同一章节的 **纯文本版本** (回退后)
+* 与其历史的 **加密字体版本** 对齐比对
+* 由此精确建立字形与真实字符之间的映射
+
+随着时间积累, 映射库会越来越完整, 从而有效覆盖绝大部分字体池和章节字体, 为模型进一步微调提供高质量训练数据
 
 **识别增强与误差控制**
 
-* 当前识别流程基于逐字图像生成与无上下文识别, 可能存在少量误差
-* 可考虑以 "多字联动识别" 为改进方向, 提高上下文信息对字符识别的约束力
-* 当前实现因复杂度未进一步深入
+当前识别流程以 **单字图像 + 无上下文 OCR** 为主，因此可能出现:
 
-如有更优的实现方式或改进建议, 欢迎通过 Issue 提出或进行补充。
+* 相似字形混淆
+* 少量识别误差
+* 字形退化带来的不稳定性
+
+可行的优化方向包括:
+
+* 加入上下文约束: 基于语言模型的 "多字联动识别", 减少歧义
+* 概率式输出整句校准: 使用 NLP 语言模型对多候选结果进行纠错
+* 字形聚类与历史映射复用: 对相似字形自动聚类, 提高映射复用率
+
+由于工程复杂度较高, 目前实现仍保持在较简洁的结构
+
+> 如有更优的实现方式或改进建议, 欢迎通过 Issue 提出或进行补充。
 
 ## 五、章节重复内容的异常与修复方法
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -380,7 +380,7 @@ class ProcessorProtocol(Protocol):
 在 `settings.toml` 中:
 
 ```toml
-[[plugins.processors]]
+[[general.processors]]
 name = "cleaner"
 overwrite = false
 config_1 = true
@@ -469,7 +469,7 @@ cleaner
 在配置文件中可直接引用:
 
 ```toml
-[[plugins.processors]]
+[[general.processors]]
 name = "cleaner"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ novel-cli = "novel_downloader.apps.cli.main:cli_main"
 novel-web = "novel_downloader.apps.web.main:web_main"
 
 [project.urls]
-Homepage = "https://github.com/saudadez21/novel-downloader"
+Homepage = "https://saudadez21.github.io/novel-downloader/"
 Source = "https://github.com/saudadez21/novel-downloader"
 Issues = "https://github.com/saudadez21/novel-downloader/issues"
 


### PR DESCRIPTION
### Description

This PR updates various documentation files, improves the project's README structure, and fixes configuration-related typos in the guide.

---

### Changes

* Fixed formatting issues in `docs/notes/` regarding **faloo** and added additional information for **qidian**.
* Updated `README.md` to simplify content and link to the new MkDocs GitHub Pages site instead of containing long-form documentation.
* Added `README.en.md` for English readers.
* Corrected a typo in `docs/guide/` related to processors configuration (`[[plugins.processors]]` -> `[[general.processors]]`).

---

### Motivation

These changes improve clarity, reduce duplication between README and documentation site, and correct configuration mistakes that might confuse users.

---

### Type of change

* [x] Documentation update

---

### Checklist

* [x] I have tested my changes locally
* [x] I have updated documentation if needed
* [x] Code follows the project's coding style

